### PR TITLE
[codex] feat(seo): automate sitemap generation and tighten meta handling

### DIFF
--- a/components/layouts/layout.js
+++ b/components/layouts/layout.js
@@ -14,6 +14,7 @@ const Layout = ({
   title,
   description = DEFAULT_DESCRIPTION,
   keywords = DEFAULT_KEYWORDS,
+  robots = "index,follow,max-image-preview:large",
   path = "",
   image = DEFAULT_OG_IMAGE,
   jsonLd = null,
@@ -33,7 +34,7 @@ const Layout = ({
         <meta name="description" content={description} />
         <meta name="author" content="Ozzo" />
         <meta name="keywords" content={keywords} />
-        <meta name="robots" content="index,follow,max-image-preview:large" />
+        <meta name="robots" content={robots} />
         {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
         <link rel="icon" href="/favicon.ico" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />

--- a/components/layouts/main.js
+++ b/components/layouts/main.js
@@ -7,15 +7,13 @@ const Main = ({ children, router }) => {
   return (
     <Box as="main" minH="100vh" display="flex" flexDirection="column">
       <Head>
-        <meta name="description" content="Ozzo's homepage" />
         <meta name="author" content="Giorgio Ozzola" />
         <link rel="apple-touch-icon" href="apple-touch-icon.png" />
         <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no"
-        />{" "}
-        <title>Ozzo - Home</title>
+        />
       </Head>
       <Navbar path={router.asPath} />
       <Container maxW="container.md" pt={24} flex="1">

--- a/components/layouts/projectdetails.js
+++ b/components/layouts/projectdetails.js
@@ -14,6 +14,7 @@ const ProjectDetailsLayout = ({
   title,
   projectTitle,
   description,
+  keywords,
   imageUrl,
   imageAlt,
   dateInfo,
@@ -39,6 +40,13 @@ const ProjectDetailsLayout = ({
             content={
               description ||
               `Project details for ${title}, built by Ozzo (full stack developer and indie builder).`
+            }
+          />
+          <meta
+            name="keywords"
+            content={
+              keywords ||
+              `${title}, software project, full stack development, indie builder, Ozzo`
             }
           />
           <meta name="robots" content="index,follow,max-image-preview:large" />

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,34 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: process.env.SITE_URL || "https://ozzo.blog",
+  generateRobotsTxt: true,
+  generateIndexSitemap: false,
+  changefreq: "weekly",
+  priority: 0.7,
+  autoLastmod: true,
+  transform: async (config, path) => {
+    let priority = 0.7;
+    let changefreq = "weekly";
+
+    if (path === "/") {
+      priority = 1.0;
+    } else if (["/articles", "/projects"].includes(path)) {
+      priority = 0.9;
+    } else if (path === "/books") {
+      priority = 0.8;
+    } else if (path.startsWith("/projects/")) {
+      priority = 0.8;
+      changefreq = "monthly";
+    } else if (path === "/contacts") {
+      priority = 0.7;
+      changefreq = "monthly";
+    }
+
+    return {
+      loc: path,
+      changefreq,
+      priority,
+      lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
+    };
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "devozzo-homepage",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "devozzo-homepage",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "@chakra-ui/icons": "^2.1.1",
         "@chakra-ui/react": "^2.8.2",
@@ -23,6 +23,7 @@
       "devDependencies": {
         "eslint": "^8.0.0",
         "eslint-config-next": "^14.2.3",
+        "next-sitemap": "^4.2.3",
         "prettier": "^3.3.0"
       }
     },
@@ -262,6 +263,13 @@
       "peerDependencies": {
         "react": ">=16.8.0"
       }
+    },
+    "node_modules/@corex/deepmerge": {
+      "version": "4.0.43",
+      "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
+      "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.4.3",
@@ -4865,6 +4873,41 @@
           "optional": true
         }
       }
+    },
+    "node_modules/next-sitemap": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-4.2.3.tgz",
+      "integrity": "sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "url": "https://github.com/iamvishnusankar/next-sitemap.git"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@corex/deepmerge": "^4.0.43",
+        "@next/env": "^13.4.3",
+        "fast-glob": "^3.2.12",
+        "minimist": "^1.2.8"
+      },
+      "bin": {
+        "next-sitemap": "bin/next-sitemap.mjs",
+        "next-sitemap-cjs": "bin/next-sitemap.cjs"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "next": "*"
+      }
+    },
+    "node_modules/next-sitemap/node_modules/@next/env": {
+      "version": "13.5.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.11.tgz",
+      "integrity": "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && next-sitemap",
     "start": "next start",
     "lint": "next lint"
   },
@@ -24,6 +24,7 @@
   "devDependencies": {
     "eslint": "^8.0.0",
     "eslint-config-next": "^14.2.3",
+    "next-sitemap": "^4.2.3",
     "prettier": "^3.3.0"
   }
 }

--- a/pages/404.js
+++ b/pages/404.js
@@ -7,19 +7,30 @@ import {
   Divider,
   Button,
 } from "@chakra-ui/react";
+import Head from "next/head";
 
 const ErrorPage = () => {
   return (
-    <Container align="center">
-      <Heading as="h1">Not found</Heading>
-      <Text>The page you&apos;re looking for was not found.</Text>
-      <Divider my={6} />
-      <Box my={6} align="center">
-        <Button as={NextLink} href="/" colorScheme="orange">
-          Return to home
-        </Button>
-      </Box>
-    </Container>
+    <>
+      <Head>
+        <title>404 — Page Not Found | Ozzo</title>
+        <meta
+          name="description"
+          content="The page you are looking for does not exist on ozzo.blog."
+        />
+        <meta name="robots" content="noindex,nofollow" />
+      </Head>
+      <Container align="center">
+        <Heading as="h1">Not found</Heading>
+        <Text>The page you&apos;re looking for was not found.</Text>
+        <Divider my={6} />
+        <Box my={6} align="center">
+          <Button as={NextLink} href="/" colorScheme="orange">
+            Return to home
+          </Button>
+        </Box>
+      </Container>
+    </>
   );
 };
 

--- a/pages/projects/fbetsapi.js
+++ b/pages/projects/fbetsapi.js
@@ -12,12 +12,14 @@ const Project = ({ project }) => {
   }
 
   const { title, description, stack, github, demo } = project;
+  const projectKeywords = `${title}, ${stack.join(", ")}, software project, full stack developer, Ozzo`;
 
   return (
     <ProjectDetailsLayout
       title={title}
       projectTitle={title}
       description={description}
+      keywords={projectKeywords}
       path="/projects/fbetsapi"
       imageUrl={project.thumbnail}
       imageAlt={title}

--- a/pages/projects/fbetsui.js
+++ b/pages/projects/fbetsui.js
@@ -12,12 +12,14 @@ const Project = ({ project }) => {
   }
 
   const { title, description, stack, github, demo } = project;
+  const projectKeywords = `${title}, ${stack.join(", ")}, software project, full stack developer, Ozzo`;
 
   return (
     <ProjectDetailsLayout
       title={title}
       projectTitle={title}
       description={description}
+      keywords={projectKeywords}
       path="/projects/fbetsui"
       imageUrl={project.thumbnail}
       imageAlt={title}

--- a/pages/projects/kellyspub.js
+++ b/pages/projects/kellyspub.js
@@ -12,12 +12,14 @@ const Project = ({ project }) => {
   }
 
   const { title, description, stack, github, demo } = project;
+  const projectKeywords = `${title}, ${stack.join(", ")}, software project, full stack developer, Ozzo`;
 
   return (
     <ProjectDetailsLayout
       title={title}
       projectTitle={title}
       description={description}
+      keywords={projectKeywords}
       path="/projects/kellyspub"
       imageUrl={project.thumbnail}
       imageAlt={title}

--- a/pages/projects/meteomapbot.js
+++ b/pages/projects/meteomapbot.js
@@ -12,12 +12,14 @@ const Project = ({ project }) => {
   }
 
   const { title, description, stack, github, demo } = project;
+  const projectKeywords = `${title}, ${stack.join(", ")}, software project, full stack developer, Ozzo`;
 
   return (
     <ProjectDetailsLayout
       title={title}
       projectTitle={title}
       description={description}
+      keywords={projectKeywords}
       path="/projects/meteomapbot"
       imageUrl={project.thumbnail}
       imageAlt={title}

--- a/pages/projects/portfolio.js
+++ b/pages/projects/portfolio.js
@@ -12,12 +12,14 @@ const Project = ({ project }) => {
   }
 
   const { title, description, stack, github, demo } = project;
+  const projectKeywords = `${title}, ${stack.join(", ")}, software project, full stack developer, Ozzo`;
 
   return (
     <ProjectDetailsLayout
       title={title}
       projectTitle={title}
       description={description}
+      keywords={projectKeywords}
       path="/projects/portfolio"
       imageUrl={project.thumbnail}
       imageAlt={title}

--- a/pages/projects/rubychess.js
+++ b/pages/projects/rubychess.js
@@ -12,12 +12,14 @@ const Project = ({ project }) => {
   }
 
   const { title, description, stack, github, demo } = project;
+  const projectKeywords = `${title}, ${stack.join(", ")}, software project, full stack developer, Ozzo`;
 
   return (
     <ProjectDetailsLayout
       title={title}
       projectTitle={title}
       description={description}
+      keywords={projectKeywords}
       path="/projects/rubychess"
       imageUrl={project.thumbnail}
       imageAlt={title}

--- a/pages/projects/synergym.js
+++ b/pages/projects/synergym.js
@@ -12,12 +12,14 @@ const Project = ({ project }) => {
   }
 
   const { title, description, stack, github, demo } = project;
+  const projectKeywords = `${title}, ${stack.join(", ")}, software project, full stack developer, Ozzo`;
 
   return (
     <ProjectDetailsLayout
       title={title}
       projectTitle={title}
       description={description}
+      keywords={projectKeywords}
       path="/projects/synergym"
       imageUrl={project.thumbnail}
       imageAlt={title}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,9 @@
+# *
 User-agent: *
 Allow: /
 
+# Host
+Host: https://ozzo.blog
+
+# Sitemaps
 Sitemap: https://ozzo.blog/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,63 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://ozzo.blog/</loc>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>https://ozzo.blog/articles</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://ozzo.blog/projects</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://ozzo.blog/books</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://ozzo.blog/contacts</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://ozzo.blog/projects/synergym</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://ozzo.blog/projects/portfolio</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://ozzo.blog/projects/rubychess</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://ozzo.blog/projects/fbetsapi</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://ozzo.blog/projects/fbetsui</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://ozzo.blog/projects/kellyspub</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://ozzo.blog/projects/meteomapbot</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>https://ozzo.blog</loc><lastmod>2026-04-16T19:37:32.783Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
+<url><loc>https://ozzo.blog/articles</loc><lastmod>2026-04-16T19:37:32.783Z</lastmod><changefreq>weekly</changefreq><priority>0.9</priority></url>
+<url><loc>https://ozzo.blog/books</loc><lastmod>2026-04-16T19:37:32.783Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+<url><loc>https://ozzo.blog/contacts</loc><lastmod>2026-04-16T19:37:32.783Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://ozzo.blog/projects</loc><lastmod>2026-04-16T19:37:32.783Z</lastmod><changefreq>weekly</changefreq><priority>0.9</priority></url>
+<url><loc>https://ozzo.blog/projects/fbetsapi</loc><lastmod>2026-04-16T19:37:32.783Z</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+<url><loc>https://ozzo.blog/projects/fbetsui</loc><lastmod>2026-04-16T19:37:32.783Z</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+<url><loc>https://ozzo.blog/projects/kellyspub</loc><lastmod>2026-04-16T19:37:32.783Z</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+<url><loc>https://ozzo.blog/projects/meteomapbot</loc><lastmod>2026-04-16T19:37:32.783Z</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+<url><loc>https://ozzo.blog/projects/portfolio</loc><lastmod>2026-04-16T19:37:32.783Z</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+<url><loc>https://ozzo.blog/projects/rubychess</loc><lastmod>2026-04-16T19:37:32.783Z</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+<url><loc>https://ozzo.blog/projects/synergym</loc><lastmod>2026-04-16T19:37:32.783Z</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+<url><loc>https://ozzo.blog/rss.xml</loc><lastmod>2026-04-16T19:37:32.783Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
## What changed
- Added `next-sitemap` and configured build to generate `sitemap.xml` and `robots.txt` automatically.
- Added `next-sitemap.config.js` with route-specific priority/changefreq rules.
- Removed duplicate global `<title>`/description in `components/layouts/main.js` to avoid metadata conflicts.
- Added `robots` override support in shared `Layout` and applied `noindex,nofollow` for `/404`.
- Added project-specific `keywords` metadata on project detail pages.

## Why
The previous SEO P0 commit (`8d765429378c8da78509ee712358a1b51ac88b80`, PR #9) introduced static robots/sitemap and stronger route metadata. This follow-up removes manual maintenance for sitemap/robots and fixes remaining metadata overlap.

## Impact
- Lower maintenance: sitemap/robots stay aligned with routes at build time.
- Cleaner indexation signals (404 noindex, no duplicated head tags).
- Better long-tail discoverability on project detail pages.

## Validation
- `npm run build` (includes `next-sitemap`) ✅
- `npm run lint` ✅