### PR TITLE
Fix WCAG AA contrast failures on homepage and index pages

### DIFF
--- a/components/cards/articlecard.js
+++ b/components/cards/articlecard.js
@@ -34,7 +34,7 @@ const ArticleCard = ({
   const hoverBorder = useColorModeValue("orange.300", "orange.600");
   const headingColor = useColorModeValue("gray.800", "gray.100");
   const bodyColor = useColorModeValue("gray.600", "gray.400");
-  const mutedColor = useColorModeValue("gray.500", "gray.500");
+  const mutedColor = useColorModeValue("gray.600", "gray.400");
 
   const isInternal = source === "internal";
   const href = isInternal ? `/articles/${slug}` : url;

--- a/components/cards/bookcard.js
+++ b/components/cards/bookcard.js
@@ -54,7 +54,7 @@ const BookCard = ({
   );
   const tagBgColor = useColorModeValue(colors.tagBg.default, colors.tagBg._dark);
   const tagTextColor = useColorModeValue(colors.tagText.default, colors.tagText._dark);
-  const metaText = useColorModeValue("gray.500", "gray.300");
+  const metaText = useColorModeValue("gray.600", "gray.300");
   const featuredGlow = useColorModeValue("orange.50", "orange.900");
   const coverPanelBg = useColorModeValue("gray.50", "blackAlpha.400");
 

--- a/libs/theme.js
+++ b/libs/theme.js
@@ -1,4 +1,4 @@
-import { extendTheme } from "@chakra-ui/react";
+import { extendTheme, theme as baseTheme } from "@chakra-ui/react";
 import { mode } from "@chakra-ui/theme-tools";
 
 const theme = extendTheme({
@@ -49,6 +49,30 @@ const theme = extendTheme({
         },
       }),
     },
+    // Chakra's default light-mode solid "orange" is white-on-orange.500
+    // (3.39:1) and ghost text is orange.600 (4.2:1) -- both fail WCAG AA.
+    // Dark mode already uses its own orange.200-bg/gray.800-text combo for
+    // solid (11.5:1) -- leave that alone, only light mode needs shifting.
+    // Every other colorScheme keeps Chakra's own formula untouched.
+    Button: {
+      variants: {
+        solid: (props) => {
+          const base = baseTheme.components.Button.variants.solid(props);
+          if (props.colorScheme !== "orange" || props.colorMode === "dark") return base;
+          return {
+            ...base,
+            bg: "orange.700",
+            _hover: { ...base._hover, bg: "orange.800" },
+            _active: { ...base._active, bg: "orange.900" },
+          };
+        },
+        ghost: (props) => {
+          const base = baseTheme.components.Button.variants.ghost(props);
+          if (props.colorScheme !== "orange") return base;
+          return { ...base, color: mode("orange.700", "orange.200")(props) };
+        },
+      },
+    },
   },
   fonts: {
     heading: "'M PLUS Rounded 1c'",
@@ -69,7 +93,7 @@ const theme = extendTheme({
       _dark: "#ffffff", // Dark mode heading
     },
     bodyText: {
-      default: "#718096", // Light mode text
+      default: "#4a5568", // Light mode text -- #718096 was 3.68-4.01:1 against card/page bg, fails AA
       _dark: "#a0aec0", // Dark mode text
     },
     tagBg: {

--- a/pages/index.js
+++ b/pages/index.js
@@ -71,7 +71,7 @@ const SectionLabel = ({ children, mt = 10 }) => (
     fontWeight="bold"
     textTransform="uppercase"
     letterSpacing="0.12em"
-    color="gray.500"
+    color="gray.600"
     _dark={{ color: "gray.400" }}
     mb={6}
     mt={mt}
@@ -183,7 +183,7 @@ const Home = ({
             </Heading>
             <Text
               fontSize="sm"
-              color="gray.500"
+              color="gray.600"
               _dark={{ color: "gray.400" }}
             >
               Building in public: Synergym, agentic systems, homelab.
@@ -333,9 +333,9 @@ const Home = ({
         <Section delay={0.3}>
           <SectionLabel>Latest writing</SectionLabel>
           {articlesError ? (
-            <Text color="gray.500">Latest writing is temporarily unavailable.</Text>
+            <Text color="gray.600" _dark={{ color: "gray.400" }}>Latest writing is temporarily unavailable.</Text>
           ) : latestArticles.length === 0 ? (
-            <Text color="gray.500">No articles yet. That gap is visible on purpose.</Text>
+            <Text color="gray.600" _dark={{ color: "gray.400" }}>No articles yet. That gap is visible on purpose.</Text>
           ) : (
             <SimpleGrid columns={{ base: 1, md: 2 }} spacing={6}>
               {latestArticles.map((article) => (
@@ -401,7 +401,8 @@ const Home = ({
                   fontWeight="bold"
                   textTransform="uppercase"
                   letterSpacing="wider"
-                  color="gray.400"
+                  color="gray.600"
+                  _dark={{ color: "gray.400" }}
                   mb={1}
                 >
                   Currently reading
@@ -409,7 +410,7 @@ const Home = ({
                 <Text fontSize="sm" fontWeight="medium">
                   {currentBook.title}
                 </Text>
-                <Text fontSize="xs" color="gray.500" _dark={{ color: "gray.400" }}>
+                <Text fontSize="xs" color="gray.600" _dark={{ color: "gray.400" }}>
                   {currentBook.author}
                 </Text>
               </Link>


### PR DESCRIPTION
## Summary

Follow-up to #19. That PR's audit found contrast issues localized to the book/article detail pages, but the same root patterns (`gray.500`, `orange.500`) are shared components used site-wide. Re-audited home, `/articles`, and `/books` with axe-core + a real theme-toggle click (Playwright's `prefers-color-scheme` simulation doesn't actually trigger this app's color mode — confirmed it silently no-ops).

- `SectionLabel`, the bio subtitle, "Currently reading" footnote, and empty/error states: static `gray.500` (3.68:1) → `gray.600` (6.92:1)
- Shared `bodyText` theme token (`#718096`, consumed by `BookCard`, `ArticleCard`, `ProjectCard`, `contacts.js`, `projects.js`): fixed once at the token level
- `ArticleCard`'s `mutedColor` used the *same* value for both light and dark mode — happened to fail in both (4.01 / 4.32). Made it mode-aware.
- Solid "orange" `Button` (CTA, active filter chips): white-on-orange.500 (3.39:1) in light mode. Added a theme override gated to `colorScheme === "orange" && light mode` — every other case falls through to Chakra's own variant function untouched. Dark mode already uses Chakra's own orange.200/gray.800 combo (11.5:1).
- Ghost "orange" `Button` text: orange.600 (4.2:1) → orange.700, same override pattern.

One self-caught regression: my first pass at the Button override forced the light-mode bg onto dark mode too while leaving dark mode's own text color — broke dark mode contrast. Caught immediately by re-running the audit in dark mode after the change, fixed by gating to light mode only.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] axe-core `color-contrast` rule across home, articles index, books index, article detail, book detail — both color modes via real toggle clicks — 0 violations
- [x] Visual screenshot check: active filter chip and CTA buttons still read as intentional "selected/primary" states, not broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)