### PR TITLE
fix: serve articles from live portfolio data

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The SEO health workflow (`.github/workflows/seo-health.yml`) runs on every PR an
 
 ## Content pipeline
 
-Articles and books are fetched at build time from [portfolio-data](https://github.com/ozzgio/portfolio-data):
+Articles and books are fetched from [portfolio-data](https://github.com/ozzgio/portfolio-data) and cached at the edge:
 
 - **Articles**: `https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json`
 - **Books**: `https://raw.githubusercontent.com/ozzgio/portfolio-data/main/books.json`

--- a/components/markdown-prose.js
+++ b/components/markdown-prose.js
@@ -178,9 +178,21 @@ export default function MarkdownProse({ children, size = "article" }) {
       const className = child?.props?.className || "";
       const match = className.match(/language-([\w-]+)/);
       const language = match?.[1];
+      const rawChildren = child?.props?.children;
+      const codeText = Array.isArray(rawChildren)
+        ? rawChildren.map((part) => String(part)).join("")
+        : String(rawChildren || "");
 
       if (className === "language-mermaid") {
-        return <MermaidDiagram chart={String(child.props.children).trim()} />;
+        const chart = codeText.trim();
+        if (!chart) {
+          return (
+            <Box as="pre" bg={codeBg} p={4} borderRadius="md" overflowX="auto" mb={paragraphMb}>
+              {children}
+            </Box>
+          );
+        }
+        return <MermaidDiagram chart={chart} />;
       }
 
       if (language) {
@@ -209,7 +221,7 @@ export default function MarkdownProse({ children, size = "article" }) {
                 },
               }}
             >
-              {String(child.props.children).replace(/\n$/, "")}
+              {codeText.replace(/\n$/, "")}
             </SyntaxHighlighter>
           </Box>
         );

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,5 @@
-// Trigger a fresh production build/deploy: the article-detail Lambda was
-// frozen on the 2026-06-19 build, predating recent portfolio-data content.
+// Touching this file forces a fresh production deploy so Vercel rebuilds
+// the article Lambda against the current portfolio-data content.
 const nextConfig = {
   reactStrictMode: true,
   webpack: (config, { dev, isServer }) => {

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,5 @@
-// Touching this file forces a fresh production deploy so Vercel rebuilds
-// the article Lambda against the current portfolio-data content.
+// Trigger a fresh production build/deploy: the article-detail Lambda was
+// frozen on the 2026-06-19 build, predating recent portfolio-data content.
 const nextConfig = {
   reactStrictMode: true,
   webpack: (config, { dev, isServer }) => {

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,3 @@
-// Trigger a fresh production build/deploy: the article-detail Lambda was
-// frozen on the 2026-06-19 build, predating recent portfolio-data content.
 const nextConfig = {
   reactStrictMode: true,
   webpack: (config, { dev, isServer }) => {

--- a/pages/articles/[slug].js
+++ b/pages/articles/[slug].js
@@ -121,32 +121,30 @@ export default function ArticleDetailPage({ article }) {
   );
 }
 
-export async function getStaticPaths() {
-  const response = await fetch(
-    "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json",
-  );
-  const articles = response.ok ? await response.json() : [];
-
-  const paths = Array.isArray(articles)
-    ? articles
-        .filter((article) => isInternalArticle(article))
-        .map((article) => ({ params: { slug: String(article.slug) } }))
-    : [];
-
+function mapArticle(article) {
   return {
-    paths,
-    fallback: "blocking",
+    title: String(article.title || ""),
+    description: String(article.description || ""),
+    date: String(article.date || ""),
+    slug: String(article.slug || ""),
+    content: getArticleBody(article),
+    tags: Array.isArray(article.tags) ? article.tags.filter(Boolean) : [],
+    book: String(article.book || ""),
+    book_url: String(article.book_url || ""),
+    thumbnail: article.thumbnail ? resolvePortfolioAssetUrl(article.thumbnail) : "",
   };
 }
 
-export async function getStaticProps({ params }) {
+export async function getServerSideProps({ params, res }) {
+  res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate=300");
+
   try {
     const response = await fetch(
       "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json",
     );
 
     if (!response.ok) {
-      return { notFound: true, revalidate: 60 };
+      return { notFound: true };
     }
 
     const articles = await response.json();
@@ -160,28 +158,15 @@ export async function getStaticProps({ params }) {
       : null;
 
     if (!article) {
-      return { notFound: true, revalidate: 60 };
+      return { notFound: true };
     }
 
     return {
       props: {
-        article: {
-          title: String(article.title || ""),
-          description: String(article.description || ""),
-          date: String(article.date || ""),
-          slug: String(article.slug || ""),
-          content: getArticleBody(article),
-          tags: Array.isArray(article.tags) ? article.tags.filter(Boolean) : [],
-          book: String(article.book || ""),
-          book_url: String(article.book_url || ""),
-          thumbnail: article.thumbnail
-            ? resolvePortfolioAssetUrl(article.thumbnail)
-            : "",
-        },
+        article: mapArticle(article),
       },
-      revalidate: 60,
     };
   } catch {
-    return { notFound: true, revalidate: 60 };
+    return { notFound: true };
   }
 }

--- a/pages/articles/[slug].js
+++ b/pages/articles/[slug].js
@@ -27,7 +27,7 @@ import {
 
 const READING_FONT = "var(--font-merriweather), Georgia, serif";
 
-export default function ArticleDetailPage({ article }) {
+export default function ArticleDetailPage({ article, fetchError, slug }) {
   const mutedText = useColorModeValue("gray.600", "gray.400");
   const ruleColor = useColorModeValue("orange.400", "orange.500");
   // orange.500 is 3.11:1 against the light page background -- fails AA.
@@ -35,7 +35,43 @@ export default function ArticleDetailPage({ article }) {
   // background (5.12:1), so this needs to vary by mode, not be a single token.
   const linkOrange = useColorModeValue("orange.700", "orange.500");
 
-  if (!article) return null;
+  if (fetchError || !article) {
+    return (
+      <Layout title="Article temporarily unavailable">
+        <Head>
+          <meta name="description" content="Article temporarily unavailable" />
+          <meta name="robots" content="noindex" />
+        </Head>
+
+        <Container maxW="2xl" py={{ base: 6, md: 10 }}>
+          <VStack align="start" spacing={6}>
+            <Link as={NextLink} href="/articles" color={linkOrange} fontWeight="semibold">
+              <HStack spacing={2}>
+                <Icon as={IoArrowBackOutline} />
+                <Text>Back to articles</Text>
+              </HStack>
+            </Link>
+
+            <VStack align="start" spacing={3} w="100%">
+              <Heading as="h1" size="lg" lineHeight="1.25" fontFamily={READING_FONT}>
+                Article temporarily unavailable
+              </Heading>
+              <Text color={mutedText} lineHeight="1.7">
+                We could not refresh this article from the upstream content source right now.
+                Please try again in a moment; if the page was already published, the cached
+                version will continue serving once it is available again.
+              </Text>
+              {slug && (
+                <Text color={mutedText} fontSize="sm">
+                  Slug: {slug}
+                </Text>
+              )}
+            </VStack>
+          </VStack>
+        </Container>
+      </Layout>
+    );
+  }
 
   const canonicalUrl = `https://ozzo.blog/articles/${article.slug}`;
   const bookReference = getArticleBookReference(article);
@@ -135,38 +171,83 @@ function mapArticle(article) {
   };
 }
 
-export async function getServerSideProps({ params, res }) {
-  res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate=300");
+const ARTICLES_URL = "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json";
+const REVALIDATE_SECONDS = 60;
+
+const fetchInternalArticles = async () => {
+  const response = await fetch(ARTICLES_URL);
+
+  if (!response.ok) {
+    return { ok: false, articles: [] };
+  }
+
+  const articles = await response.json();
+  return { ok: true, articles: Array.isArray(articles) ? articles : [] };
+};
+
+const findInternalArticle = (articles, slug) =>
+  Array.isArray(articles)
+    ? articles.find(
+        (entry) =>
+          isInternalArticle(entry) &&
+          entry?.slug === slug &&
+          getArticleBody(entry),
+      )
+    : null;
+
+export async function getStaticPaths() {
+  try {
+    const { articles } = await fetchInternalArticles();
+    const paths = articles
+      .map((article) => String(article?.slug || "").trim())
+      .filter(Boolean)
+      .map((slug) => ({ params: { slug } }));
+
+    return { paths, fallback: "blocking" };
+  } catch {
+    return { paths: [], fallback: "blocking" };
+  }
+}
+
+export async function getStaticProps({ params }) {
+  const slug = String(params?.slug || "").trim();
 
   try {
-    const response = await fetch(
-      "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json",
-    );
+    const { ok, articles } = await fetchInternalArticles();
 
-    if (!response.ok) {
-      return { notFound: true };
+    if (!ok) {
+      return {
+        props: {
+          article: null,
+          fetchError: true,
+          slug,
+        },
+        revalidate: REVALIDATE_SECONDS,
+      };
     }
 
-    const articles = await response.json();
-    const article = Array.isArray(articles)
-      ? articles.find(
-          (entry) =>
-            isInternalArticle(entry) &&
-            entry?.slug === params?.slug &&
-            getArticleBody(entry),
-        )
-      : null;
+    const article = findInternalArticle(articles, slug);
 
     if (!article) {
-      return { notFound: true };
+      return { notFound: true, revalidate: REVALIDATE_SECONDS };
     }
 
     return {
       props: {
         article: mapArticle(article),
+        fetchError: false,
+        slug,
       },
+      revalidate: REVALIDATE_SECONDS,
     };
   } catch {
-    return { notFound: true };
+    return {
+      props: {
+        article: null,
+        fetchError: true,
+        slug,
+      },
+      revalidate: REVALIDATE_SECONDS,
+    };
   }
 }

--- a/pages/articles/index.js
+++ b/pages/articles/index.js
@@ -442,7 +442,9 @@ const ArticlesPage = ({ articles, error }) => {
   );
 };
 
-export const getStaticProps = async () => {
+export const getServerSideProps = async ({ res }) => {
+  res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate=300");
+
   try {
     const response = await fetch(
       "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json",
@@ -498,10 +500,9 @@ export const getStaticProps = async () => {
       props: {
         articles: Array.isArray(articles) ? articles : [],
       },
-      revalidate: 10,
     };
   } catch (error) {
-    console.error("Failed to fetch articles in getStaticProps:", error);
+    console.error("Failed to fetch articles in getServerSideProps:", error);
     return {
       props: {
         articles: [],

--- a/pages/articles/index.js
+++ b/pages/articles/index.js
@@ -443,8 +443,6 @@ const ArticlesPage = ({ articles, error }) => {
 };
 
 export const getServerSideProps = async ({ res }) => {
-  res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate=300");
-
   try {
     const response = await fetch(
       "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json",
@@ -496,6 +494,8 @@ export const getServerSideProps = async ({ res }) => {
       })
       .filter((article) => article.title && article.url);
 
+    res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate=300");
+
     return {
       props: {
         articles: Array.isArray(articles) ? articles : [],
@@ -503,6 +503,9 @@ export const getServerSideProps = async ({ res }) => {
     };
   } catch (error) {
     console.error("Failed to fetch articles in getServerSideProps:", error);
+    res.statusCode = 503;
+    res.setHeader("Cache-Control", "no-store");
+
     return {
       props: {
         articles: [],

--- a/pages/index.js
+++ b/pages/index.js
@@ -487,8 +487,6 @@ const Home = ({
 };
 
 export async function getServerSideProps({ res }) {
-  res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate=300");
-
   const [articlesRes, booksRes] = await Promise.allSettled([
     fetch(
       "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json",
@@ -537,6 +535,13 @@ export async function getServerSideProps({ res }) {
     }
   } catch {
     // no current book is fine
+  }
+
+  if (articlesError) {
+    res.statusCode = 503;
+    res.setHeader("Cache-Control", "no-store");
+  } else {
+    res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate=300");
   }
 
   return {

--- a/pages/index.js
+++ b/pages/index.js
@@ -537,12 +537,14 @@ export async function getServerSideProps({ res }) {
     // no current book is fine
   }
 
-  if (articlesError) {
-    res.statusCode = 503;
-    res.setHeader("Cache-Control", "no-store");
-  } else {
-    res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate=300");
-  }
+  // The homepage still renders fully (with a fallback message in the
+  // latest-writing section) when only the articles fetch fails, so this
+  // stays a 200 and skips the shared cache rather than serving a 503 for a
+  // page that can render.
+  res.setHeader(
+    "Cache-Control",
+    articlesError ? "no-store" : "s-maxage=60, stale-while-revalidate=300",
+  );
 
   return {
     props: { latestArticles, articlesError, currentBook },

--- a/pages/index.js
+++ b/pages/index.js
@@ -486,7 +486,9 @@ const Home = ({
   );
 };
 
-export async function getStaticProps() {
+export async function getServerSideProps({ res }) {
+  res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate=300");
+
   const [articlesRes, booksRes] = await Promise.allSettled([
     fetch(
       "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json",
@@ -539,7 +541,6 @@ export async function getStaticProps() {
 
   return {
     props: { latestArticles, articlesError, currentBook },
-    revalidate: 3600,
   };
 }
 


### PR DESCRIPTION
## What
- Serve article pages, article listing, and homepage article snippets from live `portfolio-data` at request time.
- Keep a short edge cache (`s-maxage=60, stale-while-revalidate=300`) so content updates appear without a redeploy while staying fast.
- Harden Mermaid markdown rendering so a malformed code fence falls back to safe text instead of breaking the page.

## Why
- The live article route was stuck on a production `/500` page.
- Build-time article rendering meant every content publish depended on a redeploy.
- This change makes the blog consume the current published JSON directly, so new articles do not need a new frontend PR.

## Verification
- `node node_modules/next/dist/bin/next build` ✅
- Local `next start` returns HTTP 200 for `/articles/the-things-im-not-using-ai-for` ✅
- Local `next start` returns HTTP 200 for `/articles` and `/` ✅