### PR TITLE
fix: add 8s timeout to newsletter webhook n8n relay

### DIFF
--- a/pages/api/newsletter-webhook.js
+++ b/pages/api/newsletter-webhook.js
@@ -60,6 +60,7 @@ export default async function handler(req, res) {
         email,
         subscriber_id: body.data?.id ?? null,
       }),
+      signal: AbortSignal.timeout(8000),
     });
 
     if (!relay.ok) {


### PR DESCRIPTION
## Summary

- Adds `AbortSignal.timeout(8000)` to the `fetch` call in `/api/newsletter-webhook`
- Prevents the Vercel function from hanging until Vercel's own 10s hard limit when the Cloudflare tunnel is mid-reconnect
- Returns a clean JSON 502 within the timeout window instead of a silent gateway timeout

## Test plan

- [x] Webhook with correct secret still returns 200 on success
- [x] Webhook without secret still returns 401
- [x] Verified the tunnel is now on HTTP/2 (more stable, no idle QUIC reconnects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)