### PR TITLE
fix(articles): add timeout+retry to portfolio-data fetches

### DIFF
--- a/libs/contentUtils.js
+++ b/libs/contentUtils.js
@@ -141,11 +141,13 @@ export const formatAbsoluteDate = (dateStr) => {
 // failure. Callers own their own filtering/normalization and decide how to
 // degrade (graceful empty list, "temporarily unavailable", or notFound).
 
-const PORTFOLIO_ARTICLES_URL =
-  "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json";
-const PORTFOLIO_BOOKS_URL =
-  "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/books.json";
-const PORTFOLIO_FETCH_TIMEOUT_MS = 8000;
+const PORTFOLIO_ARTICLES_URL = `https://raw.githubusercontent.com/${DATA_REPO}/${DATA_BRANCH}/articles.json`;
+const PORTFOLIO_BOOKS_URL = `https://raw.githubusercontent.com/${DATA_REPO}/${DATA_BRANCH}/books.json`;
+// Per-attempt deadline sized so the worst case (timeout + one retry) stays
+// under Vercel's 10s serverless-function limit on the SSR pages and on the
+// on-demand fallback:"blocking" generation for new article slugs. A healthy
+// CDN response lands in well under a second, so 4s is still a generous cutoff.
+const PORTFOLIO_FETCH_TIMEOUT_MS = 4000;
 const PORTFOLIO_FETCH_RETRIES = 1;
 
 async function fetchPortfolioArray(url) {
@@ -158,8 +160,10 @@ async function fetchPortfolioArray(url) {
         const data = await response.json();
         if (Array.isArray(data)) return { ok: true, data };
       }
-    } catch {
-      // Timeout, DNS, or JSON parse error — retry once, then give up gracefully.
+    } catch (err) {
+      // Timeout, DNS, or JSON parse error — surface it so a broken upstream
+      // or a data-shape regression isn't silently swallowed, then retry.
+      console.error("portfolio-data fetch failed:", err?.message || err);
     }
     if (attempt >= PORTFOLIO_FETCH_RETRIES) return { ok: false, data: [] };
   }

--- a/libs/contentUtils.js
+++ b/libs/contentUtils.js
@@ -127,3 +127,50 @@ export const formatAbsoluteDate = (dateStr) => {
     return dateStr;
   }
 };
+
+// --- Portfolio-data fetching -------------------------------------------------
+//
+// One fetcher for every page that reads portfolio-data, so the timeout and
+// retry policy lives in exactly one place. The raw CDN is slowest in the
+// minute or two after a publish (edge revalidation) and rate-limits under
+// load; a bare fetch() with no deadline can hang past Vercel's serverless
+// timeout and surface as a 500 — almost always on the newest article, since
+// it has no cached page yet and must generate on demand.
+//
+// Returns { ok, data } where data is the validated array on success or [] on
+// failure. Callers own their own filtering/normalization and decide how to
+// degrade (graceful empty list, "temporarily unavailable", or notFound).
+
+const PORTFOLIO_ARTICLES_URL =
+  "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json";
+const PORTFOLIO_BOOKS_URL =
+  "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/books.json";
+const PORTFOLIO_FETCH_TIMEOUT_MS = 8000;
+const PORTFOLIO_FETCH_RETRIES = 1;
+
+async function fetchPortfolioArray(url) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(PORTFOLIO_FETCH_TIMEOUT_MS),
+      });
+      if (response.ok) {
+        const data = await response.json();
+        if (Array.isArray(data)) return { ok: true, data };
+      }
+    } catch {
+      // Timeout, DNS, or JSON parse error — retry once, then give up gracefully.
+    }
+    if (attempt >= PORTFOLIO_FETCH_RETRIES) return { ok: false, data: [] };
+  }
+}
+
+export async function fetchArticles() {
+  const { ok, data } = await fetchPortfolioArray(PORTFOLIO_ARTICLES_URL);
+  return { ok, articles: ok ? data : [] };
+}
+
+export async function fetchBooks() {
+  const { ok, data } = await fetchPortfolioArray(PORTFOLIO_BOOKS_URL);
+  return { ok, books: ok ? data : [] };
+}

--- a/pages/articles/[slug].js
+++ b/pages/articles/[slug].js
@@ -17,6 +17,7 @@ import NewsletterSubscribe from "../../components/NewsletterSubscribe";
 import { IoArrowBackOutline, IoCalendarOutline } from "react-icons/io5";
 import Layout from "../../components/layouts/layout";
 import {
+  fetchArticles,
   formatAbsoluteDate,
   getArticleBody,
   getArticleBookReference,
@@ -171,19 +172,7 @@ function mapArticle(article) {
   };
 }
 
-const ARTICLES_URL = "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json";
 const REVALIDATE_SECONDS = 60;
-
-const fetchInternalArticles = async () => {
-  const response = await fetch(ARTICLES_URL);
-
-  if (!response.ok) {
-    return { ok: false, articles: [] };
-  }
-
-  const articles = await response.json();
-  return { ok: true, articles: Array.isArray(articles) ? articles : [] };
-};
 
 const findInternalArticle = (articles, slug) =>
   Array.isArray(articles)
@@ -197,7 +186,7 @@ const findInternalArticle = (articles, slug) =>
 
 export async function getStaticPaths() {
   try {
-    const { articles } = await fetchInternalArticles();
+    const { articles } = await fetchArticles();
     const paths = articles
       .map((article) => String(article?.slug || "").trim())
       .filter(Boolean)
@@ -213,7 +202,7 @@ export async function getStaticProps({ params }) {
   const slug = String(params?.slug || "").trim();
 
   try {
-    const { ok, articles } = await fetchInternalArticles();
+    const { ok, articles } = await fetchArticles();
 
     if (!ok) {
       return {

--- a/pages/articles/index.js
+++ b/pages/articles/index.js
@@ -32,6 +32,7 @@ import {
 import Layout from "../../components/layouts/layout";
 import ArticleCard from "../../components/cards/articlecard";
 import {
+  fetchArticles,
   formatAbsoluteDate,
   getArticleBody,
   getArticleSummary,
@@ -444,20 +445,10 @@ const ArticlesPage = ({ articles, error }) => {
 
 export const getServerSideProps = async ({ res }) => {
   try {
-    const response = await fetch(
-      "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json",
-    );
+    const { ok, articles: articlesData } = await fetchArticles();
 
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch articles: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    const articlesData = await response.json();
-
-    if (!Array.isArray(articlesData)) {
-      throw new Error("Invalid JSON format: expected an array");
+    if (!ok) {
+      throw new Error("Failed to fetch articles from portfolio-data");
     }
 
     const articles = articlesData

--- a/pages/books/[slug].js
+++ b/pages/books/[slug].js
@@ -30,6 +30,7 @@ import {
 import RatingStar from "../../components/ratingstar";
 import Layout from "../../components/layouts/layout";
 import {
+  fetchBooks,
   formatAbsoluteDate,
   getBookSlug,
   getBookNotes,
@@ -330,10 +331,7 @@ export default function BookDetailPage({ book }) {
 }
 
 export async function getStaticPaths() {
-  const response = await fetch(
-    "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/books.json",
-  );
-  const books = response.ok ? await response.json() : [];
+  const { books } = await fetchBooks();
 
   const paths = Array.isArray(books)
     ? books
@@ -347,13 +345,10 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }) {
   try {
-    const response = await fetch(
-      "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/books.json",
-    );
+    const { ok, books } = await fetchBooks();
 
-    if (!response.ok) return { notFound: true, revalidate: 60 };
+    if (!ok) return { notFound: true, revalidate: 60 };
 
-    const books = await response.json();
     const book = Array.isArray(books)
       ? books.find((entry) => getBookSlug(entry) === params?.slug)
       : null;

--- a/pages/books/index.js
+++ b/pages/books/index.js
@@ -32,6 +32,7 @@ import {
 import Layout from "../../components/layouts/layout";
 import BookCard from "../../components/cards/bookcard";
 import {
+  fetchBooks,
   getBookSlug,
   getBookNotes,
   getBookSummary,
@@ -499,18 +500,10 @@ const BooksPage = ({ books, error }) => {
 
 export const getStaticProps = async () => {
   try {
-    const response = await fetch(
-      "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/books.json",
-    );
+    const { ok, books: booksData } = await fetchBooks();
 
-    if (!response.ok) {
-      throw new Error(`Failed to fetch books: ${response.status} ${response.statusText}`);
-    }
-
-    const booksData = await response.json();
-
-    if (!Array.isArray(booksData)) {
-      throw new Error("Invalid JSON format: expected an array");
+    if (!ok) {
+      throw new Error("Failed to fetch books from portfolio-data");
     }
 
     const books = booksData

--- a/pages/index.js
+++ b/pages/index.js
@@ -20,6 +20,8 @@ import Layout from "../components/layouts/layout";
 import BaseCard from "../components/basecard";
 import NewsletterSubscribe from "../components/NewsletterSubscribe";
 import {
+  fetchArticles,
+  fetchBooks,
   getArticleSummary,
   isInternalArticle,
   resolvePortfolioAssetUrl,
@@ -487,54 +489,40 @@ const Home = ({
 };
 
 export async function getServerSideProps({ res }) {
-  const [articlesRes, booksRes] = await Promise.allSettled([
-    fetch(
-      "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json",
-    ),
-    fetch(
-      "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/books.json",
-    ),
+  const [articlesResult, booksResult] = await Promise.allSettled([
+    fetchArticles(),
+    fetchBooks(),
   ]);
 
   let latestArticles = [];
   let articlesError = false;
   let currentBook = null;
 
-  try {
-    if (articlesRes.status === "fulfilled" && articlesRes.value.ok) {
-      const articlesData = await articlesRes.value.json();
-      if (Array.isArray(articlesData)) {
-        latestArticles = articlesData
-          .filter((article) => article && article.title && article.date)
-          .map(normalizeArticle)
-          .filter((article) => article.url)
-          .sort((a, b) => new Date(b.date) - new Date(a.date))
-          .slice(0, 2);
-      }
-    } else {
-      articlesError = true;
-    }
-  } catch {
+  const articlesPayload =
+    articlesResult.status === "fulfilled" ? articlesResult.value : null;
+  if (articlesPayload?.ok && Array.isArray(articlesPayload.articles)) {
+    latestArticles = articlesPayload.articles
+      .filter((article) => article && article.title && article.date)
+      .map(normalizeArticle)
+      .filter((article) => article.url)
+      .sort((a, b) => new Date(b.date) - new Date(a.date))
+      .slice(0, 2);
+  } else {
     articlesError = true;
   }
 
-  try {
-    if (booksRes.status === "fulfilled" && booksRes.value.ok) {
-      const booksData = await booksRes.value.json();
-      if (Array.isArray(booksData)) {
-        const reading = booksData.find(
-          (b) => b.status === "reading" && b.title && b.author,
-        );
-        if (reading) {
-          currentBook = {
-            title: String(reading.title),
-            author: String(reading.author),
-          };
-        }
-      }
+  const booksPayload =
+    booksResult.status === "fulfilled" ? booksResult.value : null;
+  if (booksPayload?.ok && Array.isArray(booksPayload.books)) {
+    const reading = booksPayload.books.find(
+      (b) => b.status === "reading" && b.title && b.author,
+    );
+    if (reading) {
+      currentBook = {
+        title: String(reading.title),
+        author: String(reading.author),
+      };
     }
-  } catch {
-    // no current book is fine
   }
 
   // The homepage still renders fully (with a fallback message in the

--- a/pages/index.js
+++ b/pages/index.js
@@ -489,7 +489,9 @@ const Home = ({
 };
 
 export async function getServerSideProps({ res }) {
-  const [articlesResult, booksResult] = await Promise.allSettled([
+  // The helpers never reject (they resolve to { ok:false } on any failure),
+  // so Promise.all is safe and each source degrades independently via .ok.
+  const [articlesPayload, booksPayload] = await Promise.all([
     fetchArticles(),
     fetchBooks(),
   ]);
@@ -498,9 +500,7 @@ export async function getServerSideProps({ res }) {
   let articlesError = false;
   let currentBook = null;
 
-  const articlesPayload =
-    articlesResult.status === "fulfilled" ? articlesResult.value : null;
-  if (articlesPayload?.ok && Array.isArray(articlesPayload.articles)) {
+  if (articlesPayload.ok && Array.isArray(articlesPayload.articles)) {
     latestArticles = articlesPayload.articles
       .filter((article) => article && article.title && article.date)
       .map(normalizeArticle)
@@ -511,9 +511,7 @@ export async function getServerSideProps({ res }) {
     articlesError = true;
   }
 
-  const booksPayload =
-    booksResult.status === "fulfilled" ? booksResult.value : null;
-  if (booksPayload?.ok && Array.isArray(booksPayload.books)) {
+  if (booksPayload.ok && Array.isArray(booksPayload.books)) {
     const reading = booksPayload.books.find(
       (b) => b.status === "reading" && b.title && b.author,
     );

--- a/pages/rss.xml.js
+++ b/pages/rss.xml.js
@@ -1,4 +1,5 @@
 import {
+  fetchArticles,
   getArticleBody,
   isInternalArticle,
   resolvePortfolioAssetUrl,
@@ -52,18 +53,10 @@ function generateRSSFeed(articles) {
 
 export async function getServerSideProps({ res }) {
   try {
-    const response = await fetch(
-      "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json",
-    );
+    const { ok, articles: articlesData } = await fetchArticles();
 
-    if (!response.ok) {
-      throw new Error(`Failed to fetch articles: ${response.status}`);
-    }
-
-    const articlesData = await response.json();
-
-    if (!Array.isArray(articlesData)) {
-      throw new Error("Invalid JSON format: expected an array");
+    if (!ok) {
+      throw new Error("Failed to fetch articles from portfolio-data");
     }
 
     const articles = articlesData


### PR DESCRIPTION
## Problem

New articles intermittently return a **500** on `/articles/[slug]` in production, while older articles work. The previous round of fixes (redeploy, ISR tweaks) kept recurring because the root cause was the fetch architecture.

## Root cause

Every page that reads `portfolio-data` called `fetch(raw.githubusercontent.com/...)` **with no deadline**. The raw CDN is slowest in the ~1–5 min window after a publish (edge revalidation) and rate-limits under load. A hanging fetch exceeds Vercel's serverless timeout → the function is killed → **500**. This lands on the *newest* article because it has no cached page yet and must generate on demand via `fallback: "blocking"`; older articles are already cached and never re-fetch on a hit.

## Fix

Centralize fetching in `libs/contentUtils.js`:

- `fetchArticles()` / `fetchBooks()` with `AbortSignal.timeout(8000)` + one retry + array validation, returning `{ ok, articles|books }`.
- Route all 7 inline fetches through it (article detail/index, homepage, RSS, both book pages).
- Per-page failure behavior unchanged (graceful empty / "temporarily unavailable" 200 / `notFound`) — only the fetch gains a deadline and a retry.

This is the same `AbortSignal.timeout` pattern already in use in `pages/api/newsletter-webhook.js`.

## Verification

- [x] `eslint` clean on all 7 files
- [x] `next build` green — new article prerenders as static HTML
- [x] `next start`: `/`, `/articles`, `/articles/i-almost-automated-the-hardest-part`, `/rss.xml`, `/books`, `/books/deep-work` all return **200**; new article body renders; RSS includes it

## Follow-up (separate PR, `portfolio-data`)

A Vercel Deploy Hook triggered from `portfolio-data`'s push workflow will rebuild this site on every publish, so new articles are generated as static HTML at build time rather than racing the raw-CDN at request time. This PR makes the live-fetch path safe; that one removes the race entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)