### PR TITLE
Add YouTube embed facade (click-to-play, no deps)

### DIFF
--- a/components/markdown-prose.js
+++ b/components/markdown-prose.js
@@ -18,6 +18,7 @@ import {
   oneDark,
   oneLight,
 } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import YoutubeEmbed, { parseYouTubeId } from "./youtube-embed";
 
 const MermaidDiagram = dynamic(() => import("./mermaid-diagram"), { ssr: false });
 
@@ -193,6 +194,20 @@ export default function MarkdownProse({ children, size = "article" }) {
           );
         }
         return <MermaidDiagram chart={chart} />;
+      }
+
+      if (className === "language-youtube") {
+        const videoUrl = codeText.trim();
+        if (videoUrl && parseYouTubeId(videoUrl)) {
+          return <YoutubeEmbed url={videoUrl} />;
+        }
+        // No recognizable URL: render the raw fence as a plain code block so
+        // a malformed embed is visible, not silently dropped.
+        return (
+          <Box as="pre" bg={codeBg} p={4} borderRadius="md" overflowX="auto" mb={paragraphMb}>
+            {children}
+          </Box>
+        );
       }
 
       if (language) {

--- a/components/youtube-embed.js
+++ b/components/youtube-embed.js
@@ -15,13 +15,17 @@ export function parseYouTubeId(value) {
   try {
     const parsed = new URL(url.startsWith("http") ? url : `https://${url}`);
     const host = parsed.hostname.replace(/^www\./, "");
+    const idPattern = /^[A-Za-z0-9_-]{11}$/;
 
     if (host === "youtu.be") {
-      return parsed.pathname.slice(1).split("/")[0] || "";
+      const id = parsed.pathname.slice(1).split("/")[0] || "";
+      return idPattern.test(id) ? id : "";
     }
 
+    if (host !== "youtube.com" && host !== "m.youtube.com") return "";
+
     const v = parsed.searchParams.get("v");
-    if (v) return v;
+    if (v && idPattern.test(v)) return v;
 
     const match = parsed.pathname.match(/\/(?:embed|shorts|live)\/([A-Za-z0-9_-]+)/);
     if (match) return match[1];

--- a/components/youtube-embed.js
+++ b/components/youtube-embed.js
@@ -1,0 +1,126 @@
+import { useState } from "react";
+import { Box } from "@chakra-ui/react";
+import { IoPlayCircle } from "react-icons/io5";
+
+// Parse a YouTube video id from any common URL form (watch?v=, youtu.be/,
+// /embed/, /shorts/, /live/) or accept a bare 11-char id. Returns "" when no
+// id can be found, which the caller treats as "not a YouTube embed" so a
+// malformed fence renders as a normal code block instead of vanishing.
+export function parseYouTubeId(value) {
+  const url = String(value || "").trim();
+  if (!url) return "";
+
+  if (/^[A-Za-z0-9_-]{11}$/.test(url)) return url;
+
+  try {
+    const parsed = new URL(url.startsWith("http") ? url : `https://${url}`);
+    const host = parsed.hostname.replace(/^www\./, "");
+
+    if (host === "youtu.be") {
+      return parsed.pathname.slice(1).split("/")[0] || "";
+    }
+
+    const v = parsed.searchParams.get("v");
+    if (v) return v;
+
+    const match = parsed.pathname.match(/\/(?:embed|shorts|live)\/([A-Za-z0-9_-]+)/);
+    if (match) return match[1];
+  } catch {
+    return "";
+  }
+
+  return "";
+}
+
+const thumbnailUrl = (id) => `https://i.ytimg.com/vi/${id}/hqdefault.jpg`;
+
+// Privacy-respecting YouTube embed (the "lite-youtube" pattern). The page
+// loads only a thumbnail image; the youtube-nocookie.com iframe is created on
+// click, so no third-party scripts or cookies run until the reader chooses to
+// play. Visual weight matches the Mermaid diagram blocks in the article body.
+export default function YoutubeEmbed({ url, title }) {
+  const [activated, setActivated] = useState(false);
+  const id = parseYouTubeId(url);
+
+  if (!id) return null;
+
+  const label = title || "YouTube video";
+
+  return (
+    <Box
+      as="div"
+      position="relative"
+      width="100%"
+      paddingBottom="56.25%"
+      mb={6}
+      borderRadius="md"
+      overflow="hidden"
+      bg="black"
+    >
+      {activated ? (
+        <Box
+          as="iframe"
+          position="absolute"
+          top="0"
+          left="0"
+          width="100%"
+          height="100%"
+          border="0"
+          src={`https://www.youtube-nocookie.com/embed/${id}?autoplay=1&rel=0`}
+          title={label}
+          loading="lazy"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+        />
+      ) : (
+        <Box
+          as="button"
+          type="button"
+          onClick={() => setActivated(true)}
+          position="absolute"
+          top="0"
+          left="0"
+          width="100%"
+          height="100%"
+          margin="0"
+          padding="0"
+          border="0"
+          background="transparent"
+          cursor="pointer"
+          aria-label={`Play ${label}`}
+          _focusVisible={{ outline: "3px solid white", outlineOffset: "-3px" }}
+        >
+          {/* hqdefault carries black bars on some videos; object-fit: cover
+              crops them. Plain <img> (not next/image) keeps next.config.js
+              untouched and avoids adding i.ytimg.com to the image optimizer. */}
+          <Box
+            as="img"
+            src={thumbnailUrl(id)}
+            alt=""
+            loading="lazy"
+            decoding="async"
+            position="absolute"
+            top="0"
+            left="0"
+            width="100%"
+            height="100%"
+            objectFit="cover"
+            opacity="0.94"
+          />
+          <Box
+            aria-hidden="true"
+            position="absolute"
+            top="50%"
+            left="50%"
+            transform="translate(-50%, -50%)"
+            color="white"
+            fontSize={{ base: "56px", md: "72px" }}
+            filter="drop-shadow(0 2px 8px rgba(0,0,0,0.7))"
+          >
+            <IoPlayCircle />
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
## What

Adds a `youtube` fenced code block that renders as a privacy-respecting, click-to-play video facade.

````markdown
```youtube
https://www.youtube.com/watch?v=0j3SW7R40SU
```
````

## Why

The blog (Next.js + `react-markdown`) had no way to embed videos. `react-markdown` v9 strips raw HTML by default, so a pasted `<iframe>` renders nothing, and there is no embed plugin in the stack.

## Approach

A **facade**, not a raw `<iframe>`:
- The page loads only a thumbnail image (`i.ytimg.com`); the `youtube-nocookie.com` iframe is created **on click**. No third-party scripts or cookies run until the reader plays — better for Core Web Vitals (relevant given the SEO-health CI check) and for reader privacy.
- **Zero new dependencies.** A raw-iframe path would require `rehype-raw` + `rehype-sanitize` (2 deps + a raw-HTML rendering surface) for little benefit on an author-controlled blog.
- Mirrors the existing `language-mermaid` fence-to-component pattern in `components/markdown-prose.js` — no new architecture.

`parseYouTubeId` accepts `watch?v=`, `youtu.be/`, `/embed/`, `/shorts/`, `/live/` and bare 11-char ids. A fence whose content is not a recognizable YouTube URL falls back to a normal code block instead of vanishing.

## Files

- `components/youtube-embed.js` (new) — the facade component + `parseYouTubeId`.
- `components/markdown-prose.js` — `language-youtube` branch in the `pre` handler, next to the mermaid branch.

## Verification

- `npm run lint` — clean.
- `npm run build` — succeeds; all article pages SSG; no SSR/import errors.
- End-to-end render through the real pipeline via a throwaway dev page (not committed): server-rendered HTML contained the correct thumbnail for `watch?v=`, `youtu.be/`, and `/shorts/` URL forms, the play buttons, **0** `youtube-nocookie` iframes on initial load (facade confirmed), and the invalid-URL case fell back to a code block.

## Rejected alternative

Raw `<iframe>` via `rehype-raw` + `rehype-sanitize`: simpler authoring, but 2 new deps, a raw-HTML rendering surface, and YouTube tracking on every page view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)