### PR TITLE
Add References block for external sources (rendering side)

### DIFF
--- a/libs/contentUtils.js
+++ b/libs/contentUtils.js
@@ -65,11 +65,17 @@ export const getArticleBookReference = (article) =>
 export const getArticleBookUrl = (article) =>
   getTextContent(article?.book_url || article?.bookUrl);
 
+// Only http(s) URLs may become clickable links. Anything else arriving
+// from upstream data (e.g. a "javascript:" scheme) is treated as no link.
+const WEB_URL = /^https?:\/\//i;
+
 // Optional frontmatter-driven citation list. The sync layer emits each
 // reference as an object (label + url), the same shape produced for the
 // "Referenced book" path. Entries missing both label and url are dropped;
 // a missing or non-array field yields [] so the References block simply
 // does not render. String entries are tolerated as label-only.
+// Non-http(s) URLs are stripped to "" (defense in depth, independent of
+// the data-side validator) so an unsafe scheme can never render as an href.
 export const getArticleReferences = (article) => {
   const raw = article?.references;
   if (!Array.isArray(raw)) return [];
@@ -83,6 +89,10 @@ export const getArticleReferences = (article) => {
       }
       return { label: getTextContent(entry), url: "" };
     })
+    .map((ref) => ({
+      label: ref.label,
+      url: WEB_URL.test(ref.url) ? ref.url : "",
+    }))
     .filter((ref) => ref.label || ref.url);
 };
 

--- a/libs/contentUtils.js
+++ b/libs/contentUtils.js
@@ -65,6 +65,27 @@ export const getArticleBookReference = (article) =>
 export const getArticleBookUrl = (article) =>
   getTextContent(article?.book_url || article?.bookUrl);
 
+// Optional frontmatter-driven citation list. The sync layer emits each
+// reference as an object (label + url), the same shape produced for the
+// "Referenced book" path. Entries missing both label and url are dropped;
+// a missing or non-array field yields [] so the References block simply
+// does not render. String entries are tolerated as label-only.
+export const getArticleReferences = (article) => {
+  const raw = article?.references;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((entry) => {
+      if (entry && typeof entry === "object") {
+        return {
+          label: getTextContent(entry.label || entry.title),
+          url: getTextContent(entry.url || entry.href),
+        };
+      }
+      return { label: getTextContent(entry), url: "" };
+    })
+    .filter((ref) => ref.label || ref.url);
+};
+
 export const isInternalArticle = (article) =>
   Boolean(getTextContent(article?.slug) && getArticleBody(article));
 

--- a/pages/articles/[slug].js
+++ b/pages/articles/[slug].js
@@ -22,6 +22,7 @@ import {
   getArticleBody,
   getArticleBookReference,
   getArticleBookUrl,
+  getArticleReferences,
   isInternalArticle,
   resolvePortfolioAssetUrl,
 } from "../../libs/contentUtils";
@@ -77,6 +78,7 @@ export default function ArticleDetailPage({ article, fetchError, slug }) {
   const canonicalUrl = `https://ozzo.blog/articles/${article.slug}`;
   const bookReference = getArticleBookReference(article);
   const bookUrl = getArticleBookUrl(article);
+  const references = Array.isArray(article.references) ? article.references : [];
 
   return (
     <Layout title={article.title}>
@@ -151,6 +153,50 @@ export default function ArticleDetailPage({ article, fetchError, slug }) {
             <MarkdownProse>{article.content}</MarkdownProse>
           </Box>
 
+          {references.length > 0 && (
+            <Box
+              w="100%"
+              borderLeftWidth="3px"
+              borderLeftColor={ruleColor}
+              pl={4}
+              py={3}
+              borderRadius="sm"
+            >
+              <Text
+                fontFamily={READING_FONT}
+                fontSize="xs"
+                fontWeight="semibold"
+                color={mutedText}
+                mb={2}
+                textTransform="uppercase"
+                letterSpacing="wider"
+              >
+                References
+              </Text>
+              <VStack align="start" spacing={1}>
+                {references.map((ref, index) => {
+                  const label = ref.label || ref.url;
+                  return ref.url ? (
+                    <Link
+                      key={index}
+                      href={ref.url}
+                      isExternal
+                      color={linkOrange}
+                      fontSize="sm"
+                      fontWeight="medium"
+                    >
+                      {label}
+                    </Link>
+                  ) : (
+                    <Text key={index} color={mutedText} fontSize="sm">
+                      {label}
+                    </Text>
+                  );
+                })}
+              </VStack>
+            </Box>
+          )}
+
           <NewsletterSubscribe w="100%" />
         </VStack>
       </Container>
@@ -168,6 +214,7 @@ function mapArticle(article) {
     tags: Array.isArray(article.tags) ? article.tags.filter(Boolean) : [],
     book: String(article.book || ""),
     book_url: String(article.book_url || ""),
+    references: getArticleReferences(article),
     thumbnail: article.thumbnail ? resolvePortfolioAssetUrl(article.thumbnail) : "",
   };
 }


### PR DESCRIPTION
## What

Adds an optional **References** block at the foot of each article — a small bordered list of external sources, for citing a couple of links per article to raise quality.

```
References
  How to Quit Your Job — Ali Abdaal x Paul Millerd   ↗
  The Pathless Path — Paul Millerd                    ↗
```

## Why

Articles currently have no structured way to cite sources. Inline body links work but clutter the canonical 7-section article shape (`rules.md`). A metadata-style block at the foot keeps the narrative clean and gives citations a consistent treatment — mirroring the existing **"Referenced book"** callout.

## Approach

Frontmatter-driven, mirroring the existing `book` / `book_url` path end to end:
- **This PR (presentation side):** `getArticleReferences(article)` normalizes a `references` array into `{label, url}` objects, rendered as a bordered `VStack` of external links below `<MarkdownProse>`.
- **Defensive by design:** missing field, non-array, empty array, and entries missing both label and url all yield `[]` → the block does not render. So this is safe to merge **before** the data side lights it up.

## Files

- `libs/contentUtils.js` — `getArticleReferences` (next to `getArticleBookReference` / `getArticleBookUrl`).
- `pages/articles/[slug].js` — import, `mapArticle` wiring, render block.

## Verification

- `npm run lint` — clean.
- `npm run build` — succeeds; all article pages SSG.
- Normalizer exercised across edge cases via a throwaway dev page (not committed): object entries → correct external links; string entry and missing-url entry → label-only plain text; empty array / missing field / non-array garbage → no links. Articles without references render unchanged.

## Companion change

A separate PR in `portfolio-data` will emit the `references` field from vault frontmatter (reusing `parse_article_book_reference`). This PR renders nothing until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)