### PR TITLE
fix(seo): harden article social metadata

### DIFF
--- a/.github/workflows/seo-health.yml
+++ b/.github/workflows/seo-health.yml
@@ -54,3 +54,27 @@ jobs:
         run: node scripts/seo-health-check.mjs
         env:
           BASE_URL: http://localhost:3000
+
+      - name: Start server with portfolio-data articles unavailable
+        run: npm start -- --port 3001 &
+        env:
+          PORTFOLIO_ARTICLES_URL: http://127.0.0.1:9/articles.json
+
+      - name: Wait for outage server to be ready
+        run: |
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:3001/ > /dev/null 2>&1; then
+              echo "Outage server is ready"
+              exit 0
+            fi
+            echo "Waiting... ($i/20)"
+            sleep 2
+          done
+          echo "Outage server did not become ready in time"
+          exit 1
+
+      - name: Verify article fallback during upstream outage
+        run: node scripts/seo-health-check.mjs
+        env:
+          BASE_URL: http://localhost:3001
+          VERIFY_ARTICLE_OUTAGE: "1"

--- a/components/layouts/layout.js
+++ b/components/layouts/layout.js
@@ -1,13 +1,16 @@
 import Head from "next/head";
 import { Flex } from "@chakra-ui/react";
+import {
+  DEFAULT_SOCIAL_IMAGE_URL,
+  SITE_URL,
+  resolveSocialImageUrl,
+} from "../../libs/socialMetadata.mjs";
 
-const SITE_URL = "https://ozzo.blog";
 const DEFAULT_TITLE = "Ozzo | From developer to independent operator";
 const DEFAULT_DESCRIPTION =
   "Field notes for experienced developers learning to find demand, ship useful software, earn attention, and build toward independent work.";
 const DEFAULT_KEYWORDS =
   "independent developer, product validation, software distribution, build in public, Ruby on Rails, solo developer, personal brand";
-const DEFAULT_OG_IMAGE = `${SITE_URL}/images/zicon.png`;
 
 const Layout = ({
   children,
@@ -18,13 +21,14 @@ const Layout = ({
   keywords = DEFAULT_KEYWORDS,
   robots = "index,follow,max-image-preview:large",
   path = "",
-  image = DEFAULT_OG_IMAGE,
+  image = DEFAULT_SOCIAL_IMAGE_URL,
   ogType = "website",
   jsonLd = null,
 }) => {
   const pageTitle = metaTitle || (title ? `${title} | Ozzo` : DEFAULT_TITLE);
   const shareTitle = socialTitle || pageTitle;
   const canonicalUrl = path ? `${SITE_URL}${path}` : null;
+  const socialImage = resolveSocialImageUrl(image);
 
   return (
     <Flex direction="column">
@@ -49,11 +53,11 @@ const Layout = ({
         <meta property="og:type" content={ogType} />
         <meta property="og:url" content={canonicalUrl || SITE_URL} />
         <meta property="og:site_name" content="Ozzo" />
-        <meta property="og:image" content={image} />
+        <meta property="og:image" content={socialImage} />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={shareTitle} />
         <meta name="twitter:description" content={description} />
-        <meta name="twitter:image" content={image} />
+        <meta name="twitter:image" content={socialImage} />
         {jsonLd && (
           <script
             type="application/ld+json"

--- a/libs/contentUtils.js
+++ b/libs/contentUtils.js
@@ -1,5 +1,9 @@
+import { resolvePortfolioAssetUrl } from "./portfolioAssets.mjs";
+
 const DATA_REPO = "ozzgio/portfolio-data";
 const DATA_BRANCH = "main";
+
+export { resolvePortfolioAssetUrl };
 
 export const getTextContent = (value) =>
   typeof value === "string" ? value.trim() : "";
@@ -11,17 +15,6 @@ export const slugify = (value = "") =>
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
-
-export const resolvePortfolioAssetUrl = (url, directory = "images") => {
-  const value = getTextContent(url);
-
-  if (!value) return "";
-  if (value.startsWith("http://") || value.startsWith("https://") || value.startsWith("/")) {
-    return value;
-  }
-
-  return `https://cdn.jsdelivr.net/gh/${DATA_REPO}@${DATA_BRANCH}/${directory}/${value}`;
-};
 
 export const stripMarkdown = (value = "") =>
   getTextContent(value)

--- a/libs/contentUtils.js
+++ b/libs/contentUtils.js
@@ -165,7 +165,12 @@ export const formatAbsoluteDate = (dateStr) => {
 // failure. Callers own their own filtering/normalization and decide how to
 // degrade (graceful empty list, "temporarily unavailable", or notFound).
 
-const PORTFOLIO_ARTICLES_URL = `https://raw.githubusercontent.com/${DATA_REPO}/${DATA_BRANCH}/articles.json`;
+// The article endpoint is overrideable for the local outage regression check.
+// Production continues to use the canonical portfolio-data URL unless an
+// explicitly supplied server-side environment variable says otherwise.
+const PORTFOLIO_ARTICLES_URL =
+  process.env.PORTFOLIO_ARTICLES_URL ||
+  `https://raw.githubusercontent.com/${DATA_REPO}/${DATA_BRANCH}/articles.json`;
 const PORTFOLIO_BOOKS_URL = `https://raw.githubusercontent.com/${DATA_REPO}/${DATA_BRANCH}/books.json`;
 // Per-attempt deadline sized so the worst case (timeout + one retry) stays
 // under Vercel's 10s serverless-function limit on the SSR pages and on the

--- a/libs/portfolioAssets.mjs
+++ b/libs/portfolioAssets.mjs
@@ -1,0 +1,19 @@
+const DATA_REPO = "ozzgio/portfolio-data";
+const DATA_BRANCH = "main";
+
+const getTextContent = (value) =>
+  typeof value === "string" ? value.trim() : "";
+
+// Keep portfolio-data image paths usable by page UI and social metadata alike.
+// Root-relative paths deliberately stay root-relative here: Layout turns those
+// into absolute URLs only when rendering social metadata.
+export const resolvePortfolioAssetUrl = (url, directory = "images") => {
+  const value = getTextContent(url);
+
+  if (!value) return "";
+  if (value.startsWith("http://") || value.startsWith("https://") || value.startsWith("/")) {
+    return value;
+  }
+
+  return `https://cdn.jsdelivr.net/gh/${DATA_REPO}@${DATA_BRANCH}/${directory}/${value}`;
+};

--- a/libs/socialMetadata.mjs
+++ b/libs/socialMetadata.mjs
@@ -1,0 +1,18 @@
+export const SITE_URL = "https://ozzo.blog";
+export const DEFAULT_SOCIAL_IMAGE_URL = `${SITE_URL}/images/zicon.png`;
+
+const resolveSiteLocalUrl = (value) =>
+  value.startsWith("/") ? `${SITE_URL}${value}` : value;
+
+export const resolveSocialImageUrl = (
+  image,
+  fallbackImage = DEFAULT_SOCIAL_IMAGE_URL,
+) => {
+  const value = typeof image === "string" ? image.trim() : "";
+  const fallback =
+    typeof fallbackImage === "string" && fallbackImage.trim()
+      ? fallbackImage.trim()
+      : DEFAULT_SOCIAL_IMAGE_URL;
+
+  return resolveSiteLocalUrl(value || fallback);
+};

--- a/scripts/seo-health-check.mjs
+++ b/scripts/seo-health-check.mjs
@@ -16,16 +16,19 @@
 import { readFileSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
+import { resolvePortfolioAssetUrl } from "../libs/portfolioAssets.mjs";
+import {
+  DEFAULT_SOCIAL_IMAGE_URL,
+  SITE_URL,
+  resolveSocialImageUrl,
+} from "../libs/socialMetadata.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
 const TIMEOUT_MS = 15_000;
-const SITE_URL = "https://ozzo.blog";
-const ARTICLE_METADATA_EXPECTATION = {
-  path: "/articles/a-pitch-is-not-proof",
-  image: "https://picsum.photos/seed/2026-08-02-a-pitch-is-not-proof/1200/630",
-};
+const PORTFOLIO_ARTICLES_URL =
+  "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json";
 
 // Pages that must carry full SEO metadata.
 const KEY_PAGES = ["/", "/articles", "/books", "/projects", "/contacts", "/experience"];
@@ -72,6 +75,53 @@ async function get(path) {
   const url = `${BASE_URL}${path}`;
   const res = await fetch(url, { signal: AbortSignal.timeout(TIMEOUT_MS) });
   return res;
+}
+
+function getArticleMetadataExpectation(articles) {
+  if (!Array.isArray(articles)) return null;
+
+  const article = articles.find((entry) => {
+    const slug = typeof entry?.slug === "string" ? entry.slug.trim() : "";
+    const thumbnail =
+      typeof entry?.thumbnail === "string" ? entry.thumbnail.trim() : "";
+    const content =
+      typeof (entry?.content || entry?.body) === "string"
+        ? (entry.content || entry.body).trim()
+        : "";
+
+    return Boolean(slug && thumbnail && content && !slug.includes("/"));
+  });
+
+  if (!article) return null;
+
+  const slug = article.slug.trim();
+  const path = `/articles/${encodeURIComponent(slug)}`;
+  const thumbnail = resolvePortfolioAssetUrl(article.thumbnail);
+
+  return {
+    path,
+    expectedCanonical: `${SITE_URL}${path}`,
+    expectedImage: resolveSocialImageUrl(thumbnail, DEFAULT_SOCIAL_IMAGE_URL),
+  };
+}
+
+async function fetchArticleMetadataExpectation() {
+  try {
+    const response = await fetch(PORTFOLIO_ARTICLES_URL, {
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      return { expectation: null, reason: `upstream returned HTTP ${response.status}` };
+    }
+
+    const expectation = getArticleMetadataExpectation(await response.json());
+    return expectation
+      ? { expectation, reason: "" }
+      : { expectation: null, reason: "no routable article with a thumbnail" };
+  } catch (err) {
+    return { expectation: null, reason: `upstream unavailable (${err.message})` };
+  }
 }
 
 // ── 1. RSS ────────────────────────────────────────────────────────────────────
@@ -145,45 +195,71 @@ for (const pagePath of KEY_PAGES) {
   if (pageOk) pass(`${pagePath} — all ${REQUIRED_TAGS.length} required tags present`);
 }
 
-// ── 4. Article-specific social metadata ───────────────────────────────────────
-console.log("\n[4] Article-specific social metadata");
-try {
-  const articlePath = ARTICLE_METADATA_EXPECTATION.path;
-  const response = await get(articlePath);
-  if (response.status !== 200) {
-    fail(`${articlePath} returned HTTP ${response.status}`);
+// ── 4. Social image URL resolution ────────────────────────────────────────────
+console.log("\n[4] Social image URL resolution");
+const socialImageCases = [
+  ["site-local image", "/images/articles/example.png", `${SITE_URL}/images/articles/example.png`],
+  ["external image", "https://cdn.example.com/article.png", "https://cdn.example.com/article.png"],
+  ["default fallback", "", DEFAULT_SOCIAL_IMAGE_URL],
+];
+
+for (const [name, image, expected] of socialImageCases) {
+  const actual = resolveSocialImageUrl(image);
+  if (actual !== expected) {
+    fail(`${name} expected ${expected}, got ${actual || "<missing>"}`);
   } else {
-    const html = await response.text();
-    const robots = getMetaContent(html, "name", "robots");
+    pass(`${name} resolves to ${actual}`);
+  }
+}
 
-    // Article data is supplied by an external repository. Keep this check
-    // stable during an upstream outage, when the route deliberately renders
-    // its noindex fallback instead of article metadata.
-    if (robots === "noindex") {
-      pass(`${articlePath} — upstream unavailable; graceful fallback rendered`);
+// ── 5. Article-specific social metadata ───────────────────────────────────────
+console.log("\n[5] Article-specific social metadata");
+const { expectation, reason } = await fetchArticleMetadataExpectation();
+
+if (!expectation) {
+  // The editorial record is external. A renamed, removed, thumbnail-less, or
+  // temporarily unavailable record should not make the site health check flaky.
+  pass(`article metadata check skipped — ${reason}`);
+} else {
+  try {
+    const response = await get(expectation.path);
+
+    if (response.status !== 200) {
+      fail(`${expectation.path} returned HTTP ${response.status}`);
     } else {
-      const expectedImage = ARTICLE_METADATA_EXPECTATION.image;
-      const expectedCanonical = `${SITE_URL}${articlePath}`;
-      const checks = [
-        ["og:image", getMetaContent(html, "property", "og:image"), expectedImage],
-        ["twitter:image", getMetaContent(html, "name", "twitter:image"), expectedImage],
-        ["og:type", getMetaContent(html, "property", "og:type"), "article"],
-        ["og:url", getMetaContent(html, "property", "og:url"), expectedCanonical],
-        ["canonical", getCanonicalHref(html), expectedCanonical],
-      ];
+      const html = await response.text();
+      const robots = getMetaContent(html, "name", "robots");
 
-      let articleOk = true;
-      for (const [name, actual, expected] of checks) {
-        if (actual !== expected) {
-          fail(`${articlePath} ${name} expected ${expected}, got ${actual || "<missing>"}`);
-          articleOk = false;
+      // During an upstream outage the route deliberately renders its noindex
+      // fallback instead of article metadata.
+      if (robots === "noindex") {
+        pass(`${expectation.path} — upstream unavailable; graceful fallback rendered`);
+      } else {
+        const checks = [
+          ["og:image", getMetaContent(html, "property", "og:image"), expectation.expectedImage],
+          ["twitter:image", getMetaContent(html, "name", "twitter:image"), expectation.expectedImage],
+          ["og:type", getMetaContent(html, "property", "og:type"), "article"],
+          ["og:url", getMetaContent(html, "property", "og:url"), expectation.expectedCanonical],
+          ["canonical", getCanonicalHref(html), expectation.expectedCanonical],
+        ];
+
+        let articleOk = true;
+        for (const [name, actual, expected] of checks) {
+          if (actual !== expected) {
+            fail(
+              `${expectation.path} ${name} expected ${expected}, got ${actual || "<missing>"}`,
+            );
+            articleOk = false;
+          }
+        }
+        if (articleOk) {
+          pass(`${expectation.path} — article thumbnail and canonical metadata`);
         }
       }
-      if (articleOk) pass(`${articlePath} — article thumbnail and canonical metadata`);
     }
+  } catch (err) {
+    fail(`${expectation.path} metadata check failed: ${err.message}`);
   }
-} catch (err) {
-  fail(`article metadata check failed: ${err.message}`);
 }
 
 // ── Result ────────────────────────────────────────────────────────────────────

--- a/scripts/seo-health-check.mjs
+++ b/scripts/seo-health-check.mjs
@@ -10,7 +10,10 @@
  *  1. RSS feed returns 200 and contains valid XML structure.
  *  2. Every URL in public/sitemap.xml returns 200.
  *  3. Key pages contain all required SEO tags.
- *  4. A published regression article exposes article-specific social metadata.
+ *  4. A current published article exposes article-specific social metadata.
+ *
+ * Set VERIFY_ARTICLE_OUTAGE=1 to run only the deterministic article-fallback
+ * check against a server whose portfolio-data article endpoint is unavailable.
  */
 
 import { readFileSync } from "fs";
@@ -27,6 +30,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
 const TIMEOUT_MS = 15_000;
+const VERIFY_ARTICLE_OUTAGE = process.env.VERIFY_ARTICLE_OUTAGE === "1";
+const ARTICLE_OUTAGE_PATH = "/articles/seo-upstream-outage";
 const PORTFOLIO_ARTICLES_URL =
   "https://raw.githubusercontent.com/ozzgio/portfolio-data/main/articles.json";
 
@@ -122,6 +127,56 @@ async function fetchArticleMetadataExpectation() {
   } catch (err) {
     return { expectation: null, reason: `upstream unavailable (${err.message})` };
   }
+}
+
+async function checkArticleOutageFallback() {
+  console.log("\n[Outage] Article fallback route");
+
+  try {
+    const response = await get(ARTICLE_OUTAGE_PATH);
+
+    if (response.status !== 200) {
+      fail(`${ARTICLE_OUTAGE_PATH} returned HTTP ${response.status}`);
+      return;
+    }
+
+    const html = await response.text();
+    const checks = [
+      ["fallback message", html.includes("Article temporarily unavailable"), true],
+      ["robots", getMetaContent(html, "name", "robots"), "noindex"],
+      ["og:image", getMetaContent(html, "property", "og:image"), DEFAULT_SOCIAL_IMAGE_URL],
+      ["twitter:image", getMetaContent(html, "name", "twitter:image"), DEFAULT_SOCIAL_IMAGE_URL],
+    ];
+
+    let fallbackOk = true;
+    for (const [name, actual, expected] of checks) {
+      if (actual !== expected) {
+        fail(
+          `${ARTICLE_OUTAGE_PATH} fallback ${name} expected ${expected}, got ${actual || "<missing>"}`,
+        );
+        fallbackOk = false;
+      }
+    }
+
+    if (fallbackOk) {
+      pass(`${ARTICLE_OUTAGE_PATH} — noindex fallback and absolute social images`);
+    }
+  } catch (err) {
+    fail(`${ARTICLE_OUTAGE_PATH} fallback request failed: ${err.message}`);
+  }
+}
+
+if (VERIFY_ARTICLE_OUTAGE) {
+  await checkArticleOutageFallback();
+
+  console.log(`\n${"─".repeat(56)}`);
+  if (failures === 0) {
+    console.log("Article outage fallback check passed.");
+    process.exit(0);
+  }
+
+  console.error(`${failures} check(s) failed.`);
+  process.exit(1);
 }
 
 // ── 1. RSS ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- emit absolute social image URLs for site-local article thumbnails
- retain external and default social images
- derive the article SEO assertion dynamically from portfolio-data

## Verification
- npm run lint
- npm run build
- BASE_URL=http://127.0.0.1:3101 node scripts/seo-health-check.mjs