### PR TITLE
fix(markdown): style responsive data tables

### DIFF
--- a/.github/workflows/seo-health.yml
+++ b/.github/workflows/seo-health.yml
@@ -55,6 +55,12 @@ jobs:
         env:
           BASE_URL: http://localhost:3000
 
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Verify Markdown table presentation
+        run: npm run verify:markdown:presentation
+
       - name: Start server with portfolio-data articles unavailable
         run: npm start -- --port 3001 &
         env:

--- a/components/markdown-prose.js
+++ b/components/markdown-prose.js
@@ -11,6 +11,13 @@ import {
   Divider,
   Code,
   Link,
+  Table,
+  TableContainer,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
   useColorModeValue,
 } from "@chakra-ui/react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -70,6 +77,7 @@ const SIZES = {
     fontSize: "17px",
     lineHeight: "1.8",
     listFontSize: "16px",
+    tableFontSize: "15px",
     paragraphMb: 6,
     listSpacing: 3,
     headingMt: { h1: 8, h2: 10, h3: 8, h4: 6 },
@@ -78,6 +86,7 @@ const SIZES = {
     fontSize: "15px",
     lineHeight: "1.75",
     listFontSize: "14px",
+    tableFontSize: "14px",
     paragraphMb: 4,
     listSpacing: 2,
     headingMt: { h1: 6, h2: 6, h3: 5, h4: 4 },
@@ -91,8 +100,11 @@ export default function MarkdownProse({ children, size = "article" }) {
   const quoteBg = useColorModeValue("orange.50", "whiteAlpha.50");
   const codeBg = useColorModeValue("gray.100", "whiteAlpha.200");
   const codeBorder = useColorModeValue("gray.200", "whiteAlpha.300");
+  const tableBorder = useColorModeValue("gray.200", "whiteAlpha.300");
+  const tableHeaderBg = useColorModeValue("gray.100", "whiteAlpha.100");
+  const tableStripeBg = useColorModeValue("gray.50", "whiteAlpha.50");
   const syntaxTheme = useColorModeValue(accessibleOneLight, accessibleOneDark);
-  const { fontSize, lineHeight, listFontSize, paragraphMb, listSpacing, headingMt } = SIZES[size] || SIZES.article;
+  const { fontSize, lineHeight, listFontSize, tableFontSize, paragraphMb, listSpacing, headingMt } = SIZES[size] || SIZES.article;
 
   const components = {
     h1: ({ children }) => (
@@ -173,6 +185,81 @@ export default function MarkdownProse({ children, size = "article" }) {
     ),
     li: ({ children }) => (
       <ListItem lineHeight={lineHeight}>{children}</ListItem>
+    ),
+    table: ({ children }) => (
+      <TableContainer
+        w="100%"
+        maxW="100%"
+        role="region"
+        aria-label="Scrollable Markdown data table. Use arrow keys to scroll horizontally."
+        tabIndex={0}
+        mb={paragraphMb}
+        overflowX="auto"
+        overflowY="hidden"
+        whiteSpace="normal"
+        borderWidth="1px"
+        borderColor={tableBorder}
+        borderRadius="md"
+        sx={{ WebkitOverflowScrolling: "touch" }}
+      >
+        <Table
+          aria-label="Markdown data table"
+          w="100%"
+          minW={{ base: "42rem", md: "100%" }}
+          size={size === "compact" ? "sm" : "md"}
+          variant="simple"
+          whiteSpace="normal"
+          sx={{ tableLayout: "auto" }}
+        >
+          {children}
+        </Table>
+      </TableContainer>
+    ),
+    thead: ({ children }) => <Thead bg={tableHeaderBg}>{children}</Thead>,
+    tbody: ({ children }) => (
+      <Tbody sx={{ "tr:nth-of-type(even)": { bg: tableStripeBg } }}>
+        {children}
+      </Tbody>
+    ),
+    tr: ({ children }) => <Tr>{children}</Tr>,
+    th: ({ children, style }) => (
+      <Th
+        scope="col"
+        px={{ base: 3, md: 4 }}
+        py={3}
+        bg={tableHeaderBg}
+        color={headingColor}
+        borderColor={tableBorder}
+        borderBottomWidth="2px"
+        fontFamily={READING_FONT}
+        fontSize={tableFontSize}
+        lineHeight="1.4"
+        textTransform="none"
+        letterSpacing="normal"
+        textAlign={style?.textAlign}
+        whiteSpace="normal"
+        wordBreak="break-word"
+      >
+        {children}
+      </Th>
+    ),
+    td: ({ children, style }) => (
+      <Td
+        px={{ base: 3, md: 4 }}
+        py={3}
+        color={bodyColor}
+        borderColor={tableBorder}
+        borderBottomWidth="1px"
+        fontFamily={READING_FONT}
+        fontSize={tableFontSize}
+        lineHeight={lineHeight}
+        verticalAlign="top"
+        textAlign={style?.textAlign}
+        whiteSpace="normal"
+        wordBreak="break-word"
+      >
+        {children}
+      </Td>
     ),
     hr: () => <Divider my={6} />,
     pre: ({ children }) => {

--- a/components/markdown-prose.js
+++ b/components/markdown-prose.js
@@ -204,8 +204,8 @@ export default function MarkdownProse({ children, size = "article" }) {
       >
         <Table
           aria-label="Markdown data table"
-          w="100%"
-          minW={{ base: "42rem", md: "100%" }}
+          w="fit-content"
+          minW="100%"
           size={size === "compact" ? "sm" : "md"}
           variant="simple"
           whiteSpace="normal"

--- a/libs/contentUtils.js
+++ b/libs/contentUtils.js
@@ -165,13 +165,15 @@ export const formatAbsoluteDate = (dateStr) => {
 // failure. Callers own their own filtering/normalization and decide how to
 // degrade (graceful empty list, "temporarily unavailable", or notFound).
 
-// The article endpoint is overrideable for the local outage regression check.
-// Production continues to use the canonical portfolio-data URL unless an
+// The endpoints are overrideable for local outage and renderer-fixture checks.
+// Production continues to use the canonical portfolio-data URLs unless an
 // explicitly supplied server-side environment variable says otherwise.
 const PORTFOLIO_ARTICLES_URL =
   process.env.PORTFOLIO_ARTICLES_URL ||
   `https://raw.githubusercontent.com/${DATA_REPO}/${DATA_BRANCH}/articles.json`;
-const PORTFOLIO_BOOKS_URL = `https://raw.githubusercontent.com/${DATA_REPO}/${DATA_BRANCH}/books.json`;
+const PORTFOLIO_BOOKS_URL =
+  process.env.PORTFOLIO_BOOKS_URL ||
+  `https://raw.githubusercontent.com/${DATA_REPO}/${DATA_BRANCH}/books.json`;
 // Per-attempt deadline sized so the worst case (timeout + one retry) stays
 // under Vercel's 10s serverless-function limit on the SSR pages and on the
 // on-demand fallback:"blocking" generation for new article slugs. A healthy

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "verify:native": "bash scripts/verify-native-fs.sh",
-    "verify:markdown": "node scripts/verify-markdown-rendering.mjs"
+    "verify:markdown": "node scripts/verify-markdown-rendering.mjs",
+    "verify:markdown:presentation": "node scripts/verify-markdown-table-presentation.mjs"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",

--- a/pages/books/[slug].js
+++ b/pages/books/[slug].js
@@ -73,6 +73,8 @@ function ReadingArc({ sections }) {
       borderLeftColor={railColor}
       ml={{ base: 2, md: 3 }}
       pl={{ base: 6, md: 8 }}
+      alignSelf="stretch"
+      minW={0}
     >
       {sections.map((section, index) => {
         const isDecision = /decision|decided/i.test(section.label);

--- a/scripts/verify-markdown-table-presentation.mjs
+++ b/scripts/verify-markdown-table-presentation.mjs
@@ -8,11 +8,15 @@ import { chromium } from "@playwright/test";
 const HOST = "127.0.0.1";
 const ARTICLE_PATH = "/articles/markdown-table-fixture";
 const BOOK_PATH = "/books/markdown-table-book-fixture";
-const TABLE_MARKDOWN = [
-  "| Left | Center | Right |",
-  "| :--- | :---: | ---: |",
-  "| A long left value | A centred value | A long right value |",
-  "| Another row | Keeps readable spacing | Tests overflow handling |",
+const SHORT_TABLE_MARKDOWN = [
+  "| Left | Right |",
+  "| :--- | ---: |",
+  "| Short value | 1 |",
+].join("\n");
+const WIDE_TABLE_MARKDOWN = [
+  "| One | Two | Three | Four | Five | Six | Seven | Eight | Nine | Ten | Eleven | Twelve | Thirteen | Fourteen |",
+  "| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |",
+  "| a | b | c | d | e | f | g | h | i | j | k | l | m | n |",
 ].join("\n");
 
 const fixtureArticles = [{
@@ -20,7 +24,12 @@ const fixtureArticles = [{
   description: "Stable renderer fixture",
   date: "2026-08-09",
   slug: "markdown-table-fixture",
-  content: ["# Markdown table fixture", "This verifies article prose.", TABLE_MARKDOWN].join("\n\n"),
+  content: [
+    "# Markdown table fixture",
+    "This verifies article prose.",
+    SHORT_TABLE_MARKDOWN,
+    WIDE_TABLE_MARKDOWN,
+  ].join("\n\n"),
 }];
 
 const fixtureBooks = [{
@@ -32,7 +41,8 @@ const fixtureBooks = [{
     "**What it teaches**",
     "This verifies the compact prose path.",
     "**Implementation**",
-    TABLE_MARKDOWN,
+    SHORT_TABLE_MARKDOWN,
+    WIDE_TABLE_MARKDOWN,
   ].join("\n\n"),
 }];
 
@@ -130,7 +140,12 @@ async function startFixtureSite(fixtureBaseUrl) {
   siteProcess.stderr.on("data", appendOutput);
 
   const baseUrl = "http://" + HOST + ":" + port;
-  await waitForSite(baseUrl, siteProcess, () => output);
+  try {
+    await waitForSite(baseUrl, siteProcess, () => output);
+  } catch (error) {
+    await stopProcess(siteProcess);
+    throw error;
+  }
 
   return { siteProcess, baseUrl };
 }
@@ -153,14 +168,14 @@ async function closeServer(server) {
   await once(server, "close");
 }
 
-async function tableMetrics(page) {
-  const table = page.locator("table").first();
+async function tableMetrics(page, tableFixture) {
+  const table = page.locator("table").nth(tableFixture.index);
   await assert.doesNotReject(
     () => table.waitFor({ state: "visible", timeout: 15_000 }),
     "Expected a visible Markdown table",
   );
 
-  return table.evaluate((element) => {
+  return table.evaluate((element, alignmentCount) => {
     const header = element.querySelector("th");
     const cell = element.querySelector("td");
     const container = element.parentElement;
@@ -180,7 +195,7 @@ async function tableMetrics(page) {
       cellBorderBottomWidth: cellStyle?.borderBottomWidth,
       cellPaddingLeft: cellStyle?.paddingLeft,
       cellFontSize: cellStyle?.fontSize,
-      cellAlignments: [...element.querySelectorAll("tbody td")].slice(0, 3).map(
+      cellAlignments: [...element.querySelectorAll("tbody td")].slice(0, alignmentCount).map(
         (item) => getComputedStyle(item).textAlign,
       ),
       containerClientWidth: container?.clientWidth ?? 0,
@@ -190,27 +205,28 @@ async function tableMetrics(page) {
       containerLabel: container?.getAttribute("aria-label"),
       containerTabIndex: container?.tabIndex,
     };
-  });
+  }, tableFixture.alignments.length);
 }
 
-function assertTablePresentation(metrics, context, mode) {
-  assert.equal(metrics.tableDisplay, "table", context.name + " " + mode + ": must retain table semantics");
-  assert.notEqual(metrics.headerBorderBottomWidth, "0px", context.name + " " + mode + ": headers need a visible separator");
-  assert.notEqual(metrics.cellBorderBottomWidth, "0px", context.name + " " + mode + ": rows need visible separators");
-  assert.ok(parseFloat(metrics.headerPaddingLeft) >= 12, context.name + " " + mode + ": headers need readable horizontal padding");
-  assert.ok(parseFloat(metrics.cellPaddingLeft) >= 12, context.name + " " + mode + ": cells need readable horizontal padding");
-  assert.equal(metrics.cellFontSize, context.fontSize, context.name + " " + mode + ": must use its configured prose size");
-  assert.deepEqual(metrics.headerAlignments, ["left", "center", "right"], context.name + " " + mode + ": must preserve GFM header alignment");
-  assert.deepEqual(metrics.cellAlignments, ["left", "center", "right"], context.name + " " + mode + ": must preserve GFM cell alignment");
-  assert.notEqual(metrics.headerBackground, "rgba(0, 0, 0, 0)", context.name + " " + mode + ": headers need a distinct surface");
-  assert.equal(metrics.containerRole, "region", context.name + " " + mode + ": horizontal scroll must be a named region");
-  assert.equal(metrics.containerTabIndex, 0, context.name + " " + mode + ": horizontal scroll must be keyboard-focusable");
-  assert.match(metrics.containerLabel || "", /scroll horizontally/i, context.name + " " + mode + ": scroll region needs instructions");
+function assertTablePresentation(metrics, context, tableFixture, mode) {
+  const label = context.name + " " + tableFixture.name + " " + mode;
+  assert.equal(metrics.tableDisplay, "table", label + ": must retain table semantics");
+  assert.notEqual(metrics.headerBorderBottomWidth, "0px", label + ": headers need a visible separator");
+  assert.notEqual(metrics.cellBorderBottomWidth, "0px", label + ": rows need visible separators");
+  assert.ok(parseFloat(metrics.headerPaddingLeft) >= 12, label + ": headers need readable horizontal padding");
+  assert.ok(parseFloat(metrics.cellPaddingLeft) >= 12, label + ": cells need readable horizontal padding");
+  assert.equal(metrics.cellFontSize, context.fontSize, label + ": must use its configured prose size");
+  assert.deepEqual(metrics.headerAlignments, tableFixture.alignments, label + ": must preserve GFM header alignment");
+  assert.deepEqual(metrics.cellAlignments, tableFixture.alignments, label + ": must preserve GFM cell alignment");
+  assert.notEqual(metrics.headerBackground, "rgba(0, 0, 0, 0)", label + ": headers need a distinct surface");
+  assert.equal(metrics.containerRole, "region", label + ": horizontal scroll must be a named region");
+  assert.equal(metrics.containerTabIndex, 0, label + ": horizontal scroll must be keyboard-focusable");
+  assert.match(metrics.containerLabel || "", /scroll horizontally/i, label + ": scroll region needs instructions");
 }
 
-async function assertMobileLayout(page, context, mode) {
-  const metrics = await tableMetrics(page);
-  assertTablePresentation(metrics, context, mode + " mobile");
+async function assertMobileLayout(page, context, tableFixture, mode) {
+  const metrics = await tableMetrics(page, tableFixture);
+  assertTablePresentation(metrics, context, tableFixture, mode + " mobile");
 
   const viewportMetrics = await page.evaluate(() => ({
     documentWidth: document.documentElement.scrollWidth,
@@ -219,18 +235,25 @@ async function assertMobileLayout(page, context, mode) {
 
   assert.ok(
     viewportMetrics.documentWidth <= viewportMetrics.viewportWidth,
-    context.name + " " + mode + " mobile: the page must not overflow horizontally (" +
+    context.name + " " + tableFixture.name + " " + mode + " mobile: the page must not overflow horizontally (" +
       viewportMetrics.documentWidth + "px > " + viewportMetrics.viewportWidth + "px; table " +
       metrics.containerClientWidth + "px / " + metrics.containerScrollWidth + "px)",
   );
   assert.ok(
     ["auto", "scroll"].includes(metrics.containerOverflowX),
-    context.name + " " + mode + " mobile: the container must handle horizontal overflow",
+    context.name + " " + tableFixture.name + " " + mode + " mobile: the container must handle horizontal overflow",
   );
-  assert.ok(
-    metrics.containerScrollWidth > metrics.containerClientWidth,
-    context.name + " " + mode + " mobile: wide tables must scroll inside the container",
-  );
+  if (tableFixture.shouldScroll) {
+    assert.ok(
+      metrics.containerScrollWidth > metrics.containerClientWidth,
+      context.name + " " + tableFixture.name + " " + mode + " mobile: wide tables must scroll inside the container",
+    );
+  } else {
+    assert.ok(
+      metrics.containerScrollWidth <= metrics.containerClientWidth + 1,
+      context.name + " " + tableFixture.name + " " + mode + " mobile: fitting tables must not force horizontal panning",
+    );
+  }
 }
 
 async function setColorMode(page, expectedMode) {
@@ -252,6 +275,10 @@ const contexts = [
   { name: "article prose", path: ARTICLE_PATH, fontSize: "15px" },
   { name: "compact book prose", path: BOOK_PATH, fontSize: "14px" },
 ];
+const tableFixtures = [
+  { name: "short table", index: 0, alignments: ["left", "right"], shouldScroll: false },
+  { name: "wide table", index: 1, alignments: Array(14).fill("left"), shouldScroll: true },
+];
 
 const fixture = await createFixtureServer();
 let site;
@@ -268,25 +295,33 @@ try {
     await page.goto(site.baseUrl + proseContext.path, { waitUntil: "networkidle" });
 
     await setColorMode(page, "light");
-    const lightMetrics = await tableMetrics(page);
-    assertTablePresentation(lightMetrics, proseContext, "light desktop");
+    const lightMetrics = await Promise.all(tableFixtures.map((tableFixture) => tableMetrics(page, tableFixture)));
+    for (const [index, metrics] of lightMetrics.entries()) {
+      assertTablePresentation(metrics, proseContext, tableFixtures[index], "light desktop");
+    }
 
     await setColorMode(page, "dark");
-    const darkMetrics = await tableMetrics(page);
-    assertTablePresentation(darkMetrics, proseContext, "dark desktop");
-    assert.notEqual(
-      darkMetrics.headerBackground,
-      lightMetrics.headerBackground,
-      proseContext.name + ": table headers must adapt to the active color mode",
-    );
+    const darkMetrics = await Promise.all(tableFixtures.map((tableFixture) => tableMetrics(page, tableFixture)));
+    for (const [index, metrics] of darkMetrics.entries()) {
+      assertTablePresentation(metrics, proseContext, tableFixtures[index], "dark desktop");
+      assert.notEqual(
+        metrics.headerBackground,
+        lightMetrics[index].headerBackground,
+        proseContext.name + " " + tableFixtures[index].name + ": table headers must adapt to the active color mode",
+      );
+    }
 
     await page.setViewportSize({ width: 390, height: 844 });
     await page.reload({ waitUntil: "networkidle" });
     await setColorMode(page, "dark");
-    await assertMobileLayout(page, proseContext, "dark");
+    for (const tableFixture of tableFixtures) {
+      await assertMobileLayout(page, proseContext, tableFixture, "dark");
+    }
 
     await setColorMode(page, "light");
-    await assertMobileLayout(page, proseContext, "light");
+    for (const tableFixture of tableFixtures) {
+      await assertMobileLayout(page, proseContext, tableFixture, "light");
+    }
   }
 
   console.log("Markdown table presentation verified with stable article and compact-book fixtures.");

--- a/scripts/verify-markdown-table-presentation.mjs
+++ b/scripts/verify-markdown-table-presentation.mjs
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { existsSync } from "node:fs";
+import { createServer } from "node:http";
+import { chromium } from "@playwright/test";
+
+const HOST = "127.0.0.1";
+const ARTICLE_PATH = "/articles/markdown-table-fixture";
+const BOOK_PATH = "/books/markdown-table-book-fixture";
+const TABLE_MARKDOWN = [
+  "| Left | Center | Right |",
+  "| :--- | :---: | ---: |",
+  "| A long left value | A centred value | A long right value |",
+  "| Another row | Keeps readable spacing | Tests overflow handling |",
+].join("\n");
+
+const fixtureArticles = [{
+  title: "Markdown table fixture",
+  description: "Stable renderer fixture",
+  date: "2026-08-09",
+  slug: "markdown-table-fixture",
+  content: ["# Markdown table fixture", "This verifies article prose.", TABLE_MARKDOWN].join("\n\n"),
+}];
+
+const fixtureBooks = [{
+  title: "Markdown table fixture book",
+  author: "Ozzo",
+  date: "2026-08-09",
+  slug: "markdown-table-book-fixture",
+  notes: [
+    "**What it teaches**",
+    "This verifies the compact prose path.",
+    "**Implementation**",
+    TABLE_MARKDOWN,
+  ].join("\n\n"),
+}];
+
+const delay = (milliseconds) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function listen(server) {
+  server.listen(0, HOST);
+  await once(server, "listening");
+  const address = server.address();
+  assert.ok(address && typeof address !== "string", "Expected a local server address");
+  return address.port;
+}
+
+async function createFixtureServer() {
+  const server = createServer((request, response) => {
+    const path = new URL(request.url || "/", "http://" + HOST).pathname;
+    const payload = path === "/articles.json"
+      ? fixtureArticles
+      : path === "/books.json"
+        ? fixtureBooks
+        : null;
+
+    if (!payload) {
+      response.writeHead(404);
+      response.end();
+      return;
+    }
+
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify(payload));
+  });
+
+  const port = await listen(server);
+  return {
+    server,
+    baseUrl: "http://" + HOST + ":" + port,
+  };
+}
+
+async function findAvailablePort() {
+  const server = createServer();
+  const port = await listen(server);
+  server.close();
+  await once(server, "close");
+  return port;
+}
+
+async function waitForSite(baseUrl, siteProcess, getOutput) {
+  const deadline = Date.now() + 30_000;
+
+  while (Date.now() < deadline) {
+    if (siteProcess.exitCode !== null) {
+      throw new Error("The fixture site exited during startup:\n" + getOutput());
+    }
+
+    try {
+      const response = await fetch(baseUrl + "/");
+      if (response.ok) return;
+    } catch {
+      // The server is still starting.
+    }
+
+    await delay(250);
+  }
+
+  throw new Error("Timed out waiting for the fixture site:\n" + getOutput());
+}
+
+async function startFixtureSite(fixtureBaseUrl) {
+  if (!existsSync(".next/BUILD_ID")) {
+    throw new Error("A production build is required before this check. Run npm run build first.");
+  }
+
+  const port = await findAvailablePort();
+  let output = "";
+  const siteProcess = spawn(
+    process.execPath,
+    ["node_modules/next/dist/bin/next", "start", "--port", String(port)],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        PORTFOLIO_ARTICLES_URL: fixtureBaseUrl + "/articles.json",
+        PORTFOLIO_BOOKS_URL: fixtureBaseUrl + "/books.json",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  const appendOutput = (chunk) => {
+    output = (output + String(chunk)).slice(-10_000);
+  };
+  siteProcess.stdout.on("data", appendOutput);
+  siteProcess.stderr.on("data", appendOutput);
+
+  const baseUrl = "http://" + HOST + ":" + port;
+  await waitForSite(baseUrl, siteProcess, () => output);
+
+  return { siteProcess, baseUrl };
+}
+
+async function stopProcess(processToStop) {
+  if (!processToStop || processToStop.exitCode !== null) return;
+
+  processToStop.kill("SIGTERM");
+  await Promise.race([once(processToStop, "exit"), delay(5_000)]);
+
+  if (processToStop.exitCode === null) {
+    processToStop.kill("SIGKILL");
+    await once(processToStop, "exit");
+  }
+}
+
+async function closeServer(server) {
+  if (!server?.listening) return;
+  server.close();
+  await once(server, "close");
+}
+
+async function tableMetrics(page) {
+  const table = page.locator("table").first();
+  await assert.doesNotReject(
+    () => table.waitFor({ state: "visible", timeout: 15_000 }),
+    "Expected a visible Markdown table",
+  );
+
+  return table.evaluate((element) => {
+    const header = element.querySelector("th");
+    const cell = element.querySelector("td");
+    const container = element.parentElement;
+    const tableStyle = getComputedStyle(element);
+    const headerStyle = header && getComputedStyle(header);
+    const cellStyle = cell && getComputedStyle(cell);
+    const containerStyle = container && getComputedStyle(container);
+
+    return {
+      tableDisplay: tableStyle.display,
+      headerBorderBottomWidth: headerStyle?.borderBottomWidth,
+      headerPaddingLeft: headerStyle?.paddingLeft,
+      headerBackground: headerStyle?.backgroundColor,
+      headerAlignments: [...element.querySelectorAll("th")].map(
+        (item) => getComputedStyle(item).textAlign,
+      ),
+      cellBorderBottomWidth: cellStyle?.borderBottomWidth,
+      cellPaddingLeft: cellStyle?.paddingLeft,
+      cellFontSize: cellStyle?.fontSize,
+      cellAlignments: [...element.querySelectorAll("tbody td")].slice(0, 3).map(
+        (item) => getComputedStyle(item).textAlign,
+      ),
+      containerClientWidth: container?.clientWidth ?? 0,
+      containerScrollWidth: container?.scrollWidth ?? 0,
+      containerOverflowX: containerStyle?.overflowX,
+      containerRole: container?.getAttribute("role"),
+      containerLabel: container?.getAttribute("aria-label"),
+      containerTabIndex: container?.tabIndex,
+    };
+  });
+}
+
+function assertTablePresentation(metrics, context, mode) {
+  assert.equal(metrics.tableDisplay, "table", context.name + " " + mode + ": must retain table semantics");
+  assert.notEqual(metrics.headerBorderBottomWidth, "0px", context.name + " " + mode + ": headers need a visible separator");
+  assert.notEqual(metrics.cellBorderBottomWidth, "0px", context.name + " " + mode + ": rows need visible separators");
+  assert.ok(parseFloat(metrics.headerPaddingLeft) >= 12, context.name + " " + mode + ": headers need readable horizontal padding");
+  assert.ok(parseFloat(metrics.cellPaddingLeft) >= 12, context.name + " " + mode + ": cells need readable horizontal padding");
+  assert.equal(metrics.cellFontSize, context.fontSize, context.name + " " + mode + ": must use its configured prose size");
+  assert.deepEqual(metrics.headerAlignments, ["left", "center", "right"], context.name + " " + mode + ": must preserve GFM header alignment");
+  assert.deepEqual(metrics.cellAlignments, ["left", "center", "right"], context.name + " " + mode + ": must preserve GFM cell alignment");
+  assert.notEqual(metrics.headerBackground, "rgba(0, 0, 0, 0)", context.name + " " + mode + ": headers need a distinct surface");
+  assert.equal(metrics.containerRole, "region", context.name + " " + mode + ": horizontal scroll must be a named region");
+  assert.equal(metrics.containerTabIndex, 0, context.name + " " + mode + ": horizontal scroll must be keyboard-focusable");
+  assert.match(metrics.containerLabel || "", /scroll horizontally/i, context.name + " " + mode + ": scroll region needs instructions");
+}
+
+async function assertMobileLayout(page, context, mode) {
+  const metrics = await tableMetrics(page);
+  assertTablePresentation(metrics, context, mode + " mobile");
+
+  const viewportMetrics = await page.evaluate(() => ({
+    documentWidth: document.documentElement.scrollWidth,
+    viewportWidth: window.innerWidth,
+  }));
+
+  assert.ok(
+    viewportMetrics.documentWidth <= viewportMetrics.viewportWidth,
+    context.name + " " + mode + " mobile: the page must not overflow horizontally (" +
+      viewportMetrics.documentWidth + "px > " + viewportMetrics.viewportWidth + "px; table " +
+      metrics.containerClientWidth + "px / " + metrics.containerScrollWidth + "px)",
+  );
+  assert.ok(
+    ["auto", "scroll"].includes(metrics.containerOverflowX),
+    context.name + " " + mode + " mobile: the container must handle horizontal overflow",
+  );
+  assert.ok(
+    metrics.containerScrollWidth > metrics.containerClientWidth,
+    context.name + " " + mode + " mobile: wide tables must scroll inside the container",
+  );
+}
+
+async function setColorMode(page, expectedMode) {
+  const currentMode = await page.evaluate(() => (
+    document.body.classList.contains("chakra-ui-dark") ? "dark" : "light"
+  ));
+
+  if (currentMode !== expectedMode) {
+    await page.getByRole("button", { name: "Toggle theme" }).click();
+  }
+
+  const resolvedMode = await page.evaluate(() => (
+    document.body.classList.contains("chakra-ui-dark") ? "dark" : "light"
+  ));
+  assert.equal(resolvedMode, expectedMode, "Expected " + expectedMode + " color mode");
+}
+
+const contexts = [
+  { name: "article prose", path: ARTICLE_PATH, fontSize: "15px" },
+  { name: "compact book prose", path: BOOK_PATH, fontSize: "14px" },
+];
+
+const fixture = await createFixtureServer();
+let site;
+let browser;
+
+try {
+  site = await startFixtureSite(fixture.baseUrl);
+  browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const page = await context.newPage();
+
+  for (const proseContext of contexts) {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(site.baseUrl + proseContext.path, { waitUntil: "networkidle" });
+
+    await setColorMode(page, "light");
+    const lightMetrics = await tableMetrics(page);
+    assertTablePresentation(lightMetrics, proseContext, "light desktop");
+
+    await setColorMode(page, "dark");
+    const darkMetrics = await tableMetrics(page);
+    assertTablePresentation(darkMetrics, proseContext, "dark desktop");
+    assert.notEqual(
+      darkMetrics.headerBackground,
+      lightMetrics.headerBackground,
+      proseContext.name + ": table headers must adapt to the active color mode",
+    );
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.reload({ waitUntil: "networkidle" });
+    await setColorMode(page, "dark");
+    await assertMobileLayout(page, proseContext, "dark");
+
+    await setColorMode(page, "light");
+    await assertMobileLayout(page, proseContext, "light");
+  }
+
+  console.log("Markdown table presentation verified with stable article and compact-book fixtures.");
+} finally {
+  await browser?.close();
+  await stopProcess(site?.siteProcess);
+  await closeServer(fixture.server);
+}


### PR DESCRIPTION
## Summary
- render GFM tables through accessible, responsive Chakra components
- preserve GFM alignment and keep compact book prose within the viewport
- gate stable article/book fixture coverage in SEO Health CI

## Validation
- npm run lint
- npm run verify:markdown
- npm run build
- npm run verify:markdown:presentation
- npm run verify:native
- BASE_URL=http://127.0.0.1:3104 node scripts/seo-health-check.mjs