### PR TITLE
fix(ui): improve mobile accessibility

### DIFF
--- a/components/cards/bookcard.js
+++ b/components/cards/bookcard.js
@@ -126,7 +126,7 @@ const BookCard = ({
               {typeof rating === "number" && rating > 0 && (
                 <HStack spacing={1}>
                   <IoStar color="#dd6b20" />
-                  <Text fontWeight="bold" color="orange.500">
+                  <Text fontWeight="bold" color="accent.link">
                     {rating.toFixed(1)}
                   </Text>
                 </HStack>

--- a/components/enhancedchip.js
+++ b/components/enhancedchip.js
@@ -1,9 +1,10 @@
 import { Box, VStack, Text, useColorModeValue } from "@chakra-ui/react";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import Image from "next/image";
 import { useState } from "react";
 
 const EnhancedChip = ({ tech, delay = 0 }) => {
+  const shouldReduceMotion = useReducedMotion();
   const bg = useColorModeValue("white", "gray.800");
   const borderColor = useColorModeValue("gray.200", "gray.600");
   const hoverBg = useColorModeValue("gray.50", "gray.700");
@@ -16,9 +17,9 @@ const EnhancedChip = ({ tech, delay = 0 }) => {
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 30 }}
+      initial={shouldReduceMotion ? false : { opacity: 0, y: 30 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.6, delay }}
+      transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.6, delay }}
     >
       <Box
         bg={bg}

--- a/components/icons/moon-hero.js
+++ b/components/icons/moon-hero.js
@@ -318,6 +318,9 @@ const MoonHero = ({ size = 220 }) => {
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(size, size);
+    renderer.domElement.style.display = "block";
+    renderer.domElement.style.maxWidth = "100%";
+    renderer.domElement.style.height = "auto";
     mount.appendChild(renderer.domElement);
 
     const scene = new THREE.Scene();
@@ -461,6 +464,7 @@ const MoonHero = ({ size = 220 }) => {
       style={{
         width: size,
         height: size,
+        maxWidth: "100%",
         cursor: "grab",
         display: "inline-block",
         touchAction: "none",

--- a/components/icons/moon-hero.js
+++ b/components/icons/moon-hero.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { useColorMode } from "@chakra-ui/react";
+import { Box, useColorMode } from "@chakra-ui/react";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import { playfairDisplay } from "../fonts";
@@ -459,17 +459,15 @@ const MoonHero = ({ size = 220 }) => {
   }, [size, colorMode]);
 
   return (
-    <div
+    <Box
       ref={mountRef}
-      style={{
-        width: size,
-        height: size,
-        maxWidth: "100%",
-        cursor: "grab",
-        display: "inline-block",
-        touchAction: "none",
-        filter: "drop-shadow(0 0 14px rgba(160,160,210,0.45))",
-      }}
+      width={{ base: "280px", sm: "340px" }}
+      maxW="100%"
+      aspectRatio={1}
+      cursor="grab"
+      display="inline-block"
+      touchAction="none"
+      filter="drop-shadow(0 0 14px rgba(160,160,210,0.45))"
     />
   );
 };

--- a/components/layouts/projectdetails.js
+++ b/components/layouts/projectdetails.js
@@ -1,5 +1,5 @@
 import { Container, Badge, Box } from "@chakra-ui/react";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import Head from "next/head";
 import { WorkImage, Title } from "../project";
 
@@ -23,15 +23,18 @@ const ProjectDetailsLayout = ({
   socialImageUrl,
   dateInfo,
   path,
-}) => (
-  <motion.article
-    initial="hidden"
-    animate="enter"
-    exit="exit"
-    variants={variants}
-    transition={{ duration: 0.4, type: "easeInOut" }}
-    style={{ position: "relative" }}
-  >
+}) => {
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <motion.article
+      initial={shouldReduceMotion ? false : "hidden"}
+      animate="enter"
+      exit="exit"
+      variants={variants}
+      transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.4, type: "easeInOut" }}
+      style={{ position: "relative" }}
+    >
     <>
       {" "}
       {title && (
@@ -133,7 +136,8 @@ const ProjectDetailsLayout = ({
         <Box mt={6}>{children}</Box>
       </Container>
     </>
-  </motion.article>
-);
+    </motion.article>
+  );
+};
 
 export default ProjectDetailsLayout;

--- a/components/section.js
+++ b/components/section.js
@@ -1,4 +1,4 @@
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { chakra, shouldForwardProp } from "@chakra-ui/react";
 
 const StyledDiv = chakra(motion.div, {
@@ -7,15 +7,19 @@ const StyledDiv = chakra(motion.div, {
   },
 });
 
-const Section = ({ children, delay = 0.5 }) => (
-  <StyledDiv
-    initial={{ y: 10, opacity: 0 }}
-    animate={{ y: 0, opacity: 1 }}
-    transition={{ duration: 0.8, delay }}
-    mb={6}
-  >
-    {children}
-  </StyledDiv>
-);
+const Section = ({ children, delay = 0.5 }) => {
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <StyledDiv
+      initial={shouldReduceMotion ? false : { y: 10, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.8, delay }}
+      mb={6}
+    >
+      {children}
+    </StyledDiv>
+  );
+};
 
 export default Section;

--- a/libs/theme.js
+++ b/libs/theme.js
@@ -18,7 +18,27 @@ const theme = extendTheme({
       "*, *::before, &::after": {
         borderColor: mode("gray.200", "gray.700")(props),
       },
+      "@media (prefers-reduced-motion: reduce)": {
+        "*, *::before, *::after": {
+          animationDuration: "0.01ms !important",
+          animationIterationCount: "1 !important",
+          scrollBehavior: "auto !important",
+          transitionDuration: "0.01ms !important",
+        },
+      },
     }),
+  },
+  semanticTokens: {
+    colors: {
+      "accent.link": {
+        default: "orange.700",
+        _dark: "orange.300",
+      },
+      "status.error": {
+        default: "red.600",
+        _dark: "red.300",
+      },
+    },
   },
   components: {
     Heading: {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,5 @@
 import { ChakraProvider } from "@chakra-ui/react";
+import { MotionConfig } from "framer-motion";
 import Layout from "../components/layouts/main";
 import theme from "../libs/theme";
 
@@ -9,9 +10,11 @@ if (typeof window !== "undefined") {
 function Website({ Component, pageProps, router }) {
   return (
     <ChakraProvider theme={theme}>
-      <Layout router={router}>
-        <Component {...pageProps} />
-      </Layout>
+      <MotionConfig reducedMotion="user">
+        <Layout router={router}>
+          <Component {...pageProps} />
+        </Layout>
+      </MotionConfig>
     </ChakraProvider>
   );
 }

--- a/pages/articles/index.js
+++ b/pages/articles/index.js
@@ -19,7 +19,7 @@ import {
   WrapItem,
 } from "@chakra-ui/react";
 import { useMemo, useState, useEffect } from "react";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import {
   IoCalendarOutline,
   IoCloseCircleOutline,
@@ -76,6 +76,7 @@ const formatDate = (dateStr) => {
 };
 
 const ArticlesPage = ({ articles, error }) => {
+  const shouldReduceMotion = useReducedMotion();
   const [selectedTag, setSelectedTag] = useState(null);
   const [sortOption, setSortOption] = useState("newest");
   const [searchQuery, setSearchQuery] = useState("");
@@ -184,9 +185,9 @@ const ArticlesPage = ({ articles, error }) => {
       path="/articles"
     >
       <MotionBox
-        initial={{ opacity: 0, y: 18 }}
+        initial={shouldReduceMotion ? false : { opacity: 0, y: 18 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.55 }}
+        transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.55 }}
       >
         <VStack spacing={8} align="stretch">
           <Box
@@ -250,7 +251,7 @@ const ArticlesPage = ({ articles, error }) => {
                   <Link
                     href="/rss.xml"
                     fontSize="sm"
-                    color="orange.500"
+                    color="accent.link"
                     fontWeight="semibold"
                     target="_blank"
                     _hover={{ textDecoration: "underline" }}
@@ -327,7 +328,7 @@ const ArticlesPage = ({ articles, error }) => {
           </Box>
 
           {error ? (
-            <Text color="red.500">{error}</Text>
+            <Text color="status.error">{error}</Text>
           ) : (
             <VStack spacing={6} align="stretch">
               <Box

--- a/pages/books/index.js
+++ b/pages/books/index.js
@@ -19,7 +19,7 @@ import {
   WrapItem,
 } from "@chakra-ui/react";
 import { useMemo, useState } from "react";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import {
   IoBookOutline,
   IoCloseCircleOutline,
@@ -67,6 +67,7 @@ const sortByDate = (a, b, direction = "desc") => {
 };
 
 const BooksPage = ({ books, error }) => {
+  const shouldReduceMotion = useReducedMotion();
   const [selectedTag, setSelectedTag] = useState(null);
   const [sortOption, setSortOption] = useState("highest_rating");
   const [searchQuery, setSearchQuery] = useState("");
@@ -212,9 +213,9 @@ const BooksPage = ({ books, error }) => {
       path="/books"
     >
       <MotionBox
-        initial={{ opacity: 0, y: 18 }}
+        initial={shouldReduceMotion ? false : { opacity: 0, y: 18 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.55 }}
+        transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.55 }}
       >
         <VStack spacing={8} align="stretch">
           <Box
@@ -344,7 +345,7 @@ const BooksPage = ({ books, error }) => {
           </Box>
 
           {error ? (
-            <Text color="red.500">{error}</Text>
+            <Text color="status.error">{error}</Text>
           ) : (
             <VStack spacing={6} align="stretch">
               <Box

--- a/pages/experience.js
+++ b/pages/experience.js
@@ -34,7 +34,7 @@ const WorkEntry = ({ title, company, companyUrl, period, location, bullets, stac
     <Box borderLeftWidth="2px" borderLeftColor={borderColor} pl={5} py={1}>
       <Heading as="h3" fontSize="md" fontWeight="semibold">{title}</Heading>
       <HStack spacing={2} mt={1} flexWrap="wrap">
-        <Link href={companyUrl} isExternal color="orange.500" fontWeight="medium" fontSize="sm">{company}</Link>
+        <Link href={companyUrl} isExternal color="accent.link" fontWeight="medium" fontSize="sm">{company}</Link>
         <Text fontSize="sm" color={mutedText}>·</Text>
         <Text fontSize="sm" color={mutedText}>{location}</Text>
         <Text fontSize="sm" color={mutedText}>·</Text>
@@ -65,7 +65,7 @@ const ProjectEntry = ({ id, title, url, period, description, stack }) => {
       <HStack spacing={3} flexWrap="wrap">
         <Heading as="h3" fontSize="md" fontWeight="semibold">{title}</Heading>
         {url && (
-          <Link href={url} isExternal color="orange.500" fontSize="sm" fontWeight="medium">{url}</Link>
+          <Link href={url} isExternal color="accent.link" fontSize="sm" fontWeight="medium">{url}</Link>
         )}
         <Text fontSize="sm" color={mutedText}>{period}</Text>
       </HStack>
@@ -222,7 +222,7 @@ const Experience = () => {
 
         <Section delay={0.6}>
           <Box textAlign="center" pt={4}>
-            <Link as={NextLink} href="/contacts" color="orange.500" fontWeight="semibold" fontSize="sm">
+            <Link as={NextLink} href="/contacts" color="accent.link" fontWeight="semibold" fontSize="sm">
               Want to work together? Get in touch →
             </Link>
           </Box>

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,7 +7,6 @@ import {
   Link,
   SimpleGrid,
   Text,
-  useBreakpointValue,
   VStack,
 } from "@chakra-ui/react";
 import { ChevronRightIcon, ExternalLinkIcon } from "@chakra-ui/icons";
@@ -107,10 +106,6 @@ const Home = ({
   articlesError = false,
   currentBook = null,
 }) => {
-  const moonSize = useBreakpointValue(
-    { base: 280, sm: 340 },
-    { fallback: "base" }
-  );
   const homepageSchema = {
     "@context": "https://schema.org",
     "@graph": [
@@ -151,7 +146,7 @@ const Home = ({
     >
       {/* Hero */}
       <Box textAlign="center" pt={4} mb={2}>
-        <MoonHero size={moonSize || 280} />
+                  <MoonHero size={340} />
       </Box>
 
       <Container>

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,6 +7,7 @@ import {
   Link,
   SimpleGrid,
   Text,
+  useBreakpointValue,
   VStack,
 } from "@chakra-ui/react";
 import { ChevronRightIcon, ExternalLinkIcon } from "@chakra-ui/icons";
@@ -31,10 +32,18 @@ import {
 // keep it out of the homepage's initial bundle, same pattern already used
 // for MermaidDiagram in markdown-prose.js. A same-size loading placeholder
 // reserves the 340x340 hero's layout space so hydration doesn't shift the
-// statement/profile content below it (CLS).
+// statement/profile content below it (CLS). The canvas has a smaller base
+// size so it fits alongside the homepage's mobile gutters.
 const MoonHero = dynamic(() => import("../components/icons/moon-hero"), {
   ssr: false,
-  loading: () => <Box width={340} height={340} display="inline-block" />,
+  loading: () => (
+    <Box
+      width={{ base: "280px", sm: "340px" }}
+      maxW="100%"
+      aspectRatio={1}
+      display="inline-block"
+    />
+  ),
 });
 
 const formatAbsoluteDate = (dateStr) => {
@@ -98,6 +107,10 @@ const Home = ({
   articlesError = false,
   currentBook = null,
 }) => {
+  const moonSize = useBreakpointValue(
+    { base: 280, sm: 340 },
+    { fallback: "base" }
+  );
   const homepageSchema = {
     "@context": "https://schema.org",
     "@graph": [
@@ -138,7 +151,7 @@ const Home = ({
     >
       {/* Hero */}
       <Box textAlign="center" pt={4} mb={2}>
-        <MoonHero size={340} />
+        <MoonHero size={moonSize || 280} />
       </Box>
 
       <Container>

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -12,10 +12,9 @@ import {
   useColorModeValue,
   useTheme,
 } from "@chakra-ui/react";
-import { ExternalLinkIcon } from "@chakra-ui/icons";
-import { motion } from "framer-motion";
+import { ChevronRightIcon, ExternalLinkIcon } from "@chakra-ui/icons";
+import { motion, useReducedMotion } from "framer-motion";
 import NextLink from "next/link";
-import { useRouter } from "next/router";
 import Image from "next/image";
 import Layout from "../components/layouts/layout";
 import BaseCard from "../components/basecard";
@@ -107,7 +106,11 @@ const ProofLinks = ({ demo, github, size = "sm" }) => {
             rel="noopener noreferrer"
             fontSize={size}
             fontWeight="semibold"
-            onClick={(e) => e.stopPropagation()}
+            display="inline-flex"
+            alignItems="center"
+            minH="44px"
+            px={2}
+            mx={-2}
           >
             live <ExternalLinkIcon mx="4px" fontSize="xs" />
           </Link>
@@ -121,7 +124,11 @@ const ProofLinks = ({ demo, github, size = "sm" }) => {
             rel="noopener noreferrer"
             fontSize={size}
             fontWeight="semibold"
-            onClick={(e) => e.stopPropagation()}
+            display="inline-flex"
+            alignItems="center"
+            minH="44px"
+            px={2}
+            mx={-2}
           >
             repo <ExternalLinkIcon mx="4px" fontSize="xs" />
           </Link>
@@ -147,7 +154,6 @@ const SectionLabel = ({ children }) => (
 );
 
 const NowCard = ({ project }) => {
-  const router = useRouter();
   const { colors } = useTheme();
   const bodyText = useColorModeValue(colors.bodyText.default, colors.bodyText._dark);
   const headingText = useColorModeValue(colors.headingText.default, colors.headingText._dark);
@@ -160,8 +166,6 @@ const NowCard = ({ project }) => {
       p={0}
       maxW="none"
       mx="0"
-      cursor="pointer"
-      onClick={() => router.push(`/projects/${id}`)}
     >
       <Flex direction={{ base: "column", md: "row" }} minH={{ md: "220px" }}>
         <Box
@@ -193,7 +197,7 @@ const NowCard = ({ project }) => {
               as={NextLink}
               href={`/projects/${id}`}
               color={headingText}
-              _hover={{ textDecoration: "none", color: "orange.500" }}
+              _hover={{ textDecoration: "none", color: "accent.link" }}
             >
               {title}
             </Link>
@@ -202,6 +206,17 @@ const NowCard = ({ project }) => {
             {description}
           </Text>
           <Box mb={3}>
+            <Link
+              as={NextLink}
+              href={`/projects/${id}`}
+              display="inline-flex"
+              alignItems="center"
+              minH="44px"
+              fontSize="sm"
+              fontWeight="semibold"
+            >
+              View project <ChevronRightIcon ml={1} />
+            </Link>
             <ProofLinks demo={demo} github={github} />
           </Box>
           <TechStack stack={stack} />
@@ -213,7 +228,6 @@ const NowCard = ({ project }) => {
 };
 
 const ShippedCard = ({ project }) => {
-  const router = useRouter();
   const { colors } = useTheme();
   const bodyText = useColorModeValue(colors.bodyText.default, colors.bodyText._dark);
   const headingText = useColorModeValue(colors.headingText.default, colors.headingText._dark);
@@ -230,8 +244,6 @@ const ShippedCard = ({ project }) => {
       display="flex"
       flexDirection="column"
       h="100%"
-      cursor="pointer"
-      onClick={() => router.push(`/projects/${id}`)}
     >
       <Box
         w="100%"
@@ -255,7 +267,7 @@ const ShippedCard = ({ project }) => {
             as={NextLink}
             href={`/projects/${id}`}
             color={headingText}
-            _hover={{ textDecoration: "none", color: "orange.500" }}
+            _hover={{ textDecoration: "none", color: "accent.link" }}
           >
             {title}
           </Link>
@@ -267,6 +279,17 @@ const ShippedCard = ({ project }) => {
           {description}
         </Text>
         <Box mb={3}>
+          <Link
+            as={NextLink}
+            href={`/projects/${id}`}
+            display="inline-flex"
+            alignItems="center"
+            minH="44px"
+            fontSize="sm"
+            fontWeight="semibold"
+          >
+            View project <ChevronRightIcon ml={1} />
+          </Link>
           <ProofLinks demo={demo} github={github} />
         </Box>
         <TechStack stack={stack} />
@@ -289,7 +312,7 @@ const EarlierItem = ({ project }) => {
           href={`/projects/${id}`}
           fontWeight="medium"
           fontSize="sm"
-          _hover={{ textDecoration: "none", color: "orange.500" }}
+          _hover={{ textDecoration: "none", color: "accent.link" }}
         >
           {title}
         </Link>
@@ -319,6 +342,7 @@ const EarlierItem = ({ project }) => {
 };
 
 const Projects = () => {
+  const shouldReduceMotion = useReducedMotion();
   const muted = useColorModeValue("gray.500", "gray.400");
   const byEffortDesc = (a, b) => (b.effort ?? 0) - (a.effort ?? 0);
   const now = projectData.filter((p) => p.focus === "now").sort(byEffortDesc);
@@ -333,9 +357,9 @@ const Projects = () => {
       path="/projects"
     >
       <MotionBox
-        initial={{ opacity: 0, y: 20 }}
+        initial={shouldReduceMotion ? false : { opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6 }}
+        transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.6 }}
       >
         <Container maxW="container.lg" px={[2, 4, 8]}>
           <Heading

--- a/pages/projects/buildlog.js
+++ b/pages/projects/buildlog.js
@@ -67,14 +67,14 @@ const Project = ({ project }) => {
       </List>
 
       <Box mt={8}>
-        <Heading as="h3" fontSize="lg" mb={3}>
+        <Heading as="h2" fontSize="lg" mb={3}>
           What it is
         </Heading>
         <P>
           A tiny Rails app where I post short daily entries. What I built or learned,
           two or three sentences, a timestamp, an optional tag. Public feed, newest
           first. My dev journal, live at{" "}
-          <Link href="https://log.ozzo.blog" target="_blank" rel="noopener noreferrer" color="orange.500" _dark={{ color: "orange.300" }}>
+          <Link href="https://log.ozzo.blog" target="_blank" rel="noopener noreferrer" color="accent.link">
             log.ozzo.blog
           </Link>
           .
@@ -82,7 +82,7 @@ const Project = ({ project }) => {
       </Box>
 
       <Box mt={8}>
-        <Heading as="h3" fontSize="lg" mb={3}>
+        <Heading as="h2" fontSize="lg" mb={3}>
           What it isn&apos;t
         </Heading>
         <P>
@@ -94,7 +94,7 @@ const Project = ({ project }) => {
       </Box>
 
       <Box mt={8}>
-        <Heading as="h3" fontSize="lg" mb={3}>
+        <Heading as="h2" fontSize="lg" mb={3}>
           Why it exists
         </Heading>
         <P>
@@ -103,8 +103,7 @@ const Project = ({ project }) => {
             href="https://basecamp.com/shapeup"
             target="_blank"
             rel="noopener noreferrer"
-            color="orange.500"
-            _dark={{ color: "orange.300" }}
+            color="accent.link"
           >
             Shape Up
           </Link>{" "}
@@ -118,7 +117,7 @@ const Project = ({ project }) => {
       </Box>
 
       <Box mt={8}>
-        <Heading as="h3" fontSize="lg" mb={3}>
+        <Heading as="h2" fontSize="lg" mb={3}>
           What I&apos;m still figuring out
         </Heading>
         <P>

--- a/pages/projects/synergym.js
+++ b/pages/projects/synergym.js
@@ -57,7 +57,7 @@ const Project = ({ project }) => {
       </List>
 
       <Box mt={8}>
-        <Heading as="h3" fontSize="lg" mb={3}>What it does</Heading>
+        <Heading as="h2" fontSize="lg" mb={3}>What it does</Heading>
         <P>
           Gym management SaaS for trainers and athletes. Trainers create workout programs, assign them to athletes,
           manage an exercise library, and track progress. Athletes log sessions and follow assigned plans. Role-based
@@ -73,7 +73,7 @@ const Project = ({ project }) => {
       </Box>
 
       <Box mt={8}>
-        <Heading as="h3" fontSize="lg" mb={3}>The architecture work</Heading>
+        <Heading as="h2" fontSize="lg" mb={3}>The architecture work</Heading>
         <P>
           The codebase accumulated the way most codebases do. Each local decision looked reasonable. The bill
           arrived later. By early 2026 I had three files carrying everything:
@@ -101,8 +101,7 @@ const Project = ({ project }) => {
           The full reasoning is in the{" "}
           <Link
             href="/articles/rails-architecture-accumulated-by-default"
-            color="orange.500"
-            _dark={{ color: "orange.300" }}
+            color="accent.link"
           >
             architecture article
           </Link>
@@ -111,7 +110,7 @@ const Project = ({ project }) => {
       </Box>
 
       <Box mt={8}>
-        <Heading as="h3" fontSize="lg" mb={3}>What I&apos;m still figuring out</Heading>
+        <Heading as="h2" fontSize="lg" mb={3}>What I&apos;m still figuring out</Heading>
         <P>
           The technical side is in decent shape. The codebase has documented architecture decisions, a CI gate
           that enforces structural boundaries, and E2E coverage for the critical paths. That part I can execute.


### PR DESCRIPTION
## Summary
- make the home canvas responsive at 320px
- improve contrast, reduced-motion support, project-card semantics, and heading order

## Validation
- npm run lint
- npm run build
- Playwright at 320px (no horizontal overflow, reduced motion, project links)
- local production server verified; ozzoblog-dev.nuc currently returns an upstream 502 independent of this branch