### PR TITLE
fix(ui): complete full-surface audit

### DIFF
--- a/components/NewsletterSubscribe.js
+++ b/components/NewsletterSubscribe.js
@@ -71,6 +71,7 @@ const NewsletterSubscribe = (props) => {
           onChange={(event) => setEmail(event.target.value)}
           isDisabled={status === STATUS.LOADING}
           size="md"
+          minH="44px"
           maxW={{ base: "100%", sm: "320px" }}
         />
         <Button
@@ -78,6 +79,7 @@ const NewsletterSubscribe = (props) => {
           colorScheme="orange"
           isDisabled={status === STATUS.LOADING}
           size="md"
+          minH="44px"
           flexShrink={0}
         >
           {status === STATUS.LOADING ? "Subscribing…" : "Subscribe"}

--- a/components/linkitem.js
+++ b/components/linkitem.js
@@ -14,6 +14,9 @@ const LinkItem = ({ href, path, target, children, ...props }) => {
       scroll={false}
       p={2}
       px={3}
+      minH="44px"
+      display="inline-flex"
+      alignItems="center"
       borderRadius="md"
       color={active ? activeColor : inactiveColor}
       target={target}

--- a/components/markdown-prose.js
+++ b/components/markdown-prose.js
@@ -191,7 +191,7 @@ export default function MarkdownProse({ children, size = "article" }) {
         w="100%"
         maxW="100%"
         role="region"
-        aria-label="Scrollable Markdown data table. Use arrow keys to scroll horizontally."
+        aria-label="Markdown data table. Scroll horizontally on smaller screens."
         tabIndex={0}
         mb={paragraphMb}
         overflowX="auto"
@@ -205,7 +205,7 @@ export default function MarkdownProse({ children, size = "article" }) {
         <Table
           aria-label="Markdown data table"
           w="fit-content"
-          minW="100%"
+          minW={{ base: "36rem", md: "100%" }}
           size={size === "compact" ? "sm" : "md"}
           variant="simple"
           whiteSpace="normal"

--- a/components/markdown-prose.js
+++ b/components/markdown-prose.js
@@ -93,6 +93,59 @@ const SIZES = {
   },
 };
 
+const TABLE_CELL_HORIZONTAL_PADDING = 24;
+const TABLE_MINIMUM_COLUMN_WIDTH = 48;
+const TABLE_CHARACTER_WIDTH = 8;
+
+function markdownNodeText(node) {
+  if (!node || typeof node !== "object") return "";
+  if (typeof node.value === "string") return node.value;
+  if (typeof node.alt === "string") return node.alt;
+  return Array.isArray(node.children)
+    ? node.children.map(markdownNodeText).join("")
+    : "";
+}
+
+function tableContentMinWidth(tableNode) {
+  const tableChildren = Array.isArray(tableNode?.children)
+    ? tableNode.children
+    : [];
+  const rows = tableChildren.flatMap((child) => {
+    if (child.type === "tableRow" || child.tagName === "tr") return [child];
+    return Array.isArray(child.children)
+      ? child.children.filter(
+        (row) => row.type === "tableRow" || row.tagName === "tr",
+      )
+      : [];
+  });
+  const columnWidths = [];
+
+  rows.forEach((row) => {
+    const cells = Array.isArray(row.children)
+      ? row.children.filter(
+        (cell) => cell.type === "tableCell" || cell.tagName === "td" || cell.tagName === "th",
+      )
+      : [];
+    cells.forEach((cell, columnIndex) => {
+      const words = markdownNodeText(cell).match(/\S+/g) || [];
+      const longestWord = words.reduce(
+        (length, word) => Math.max(length, word.length),
+        0,
+      );
+      const readableWidth = Math.max(
+        TABLE_MINIMUM_COLUMN_WIDTH,
+        longestWord * TABLE_CHARACTER_WIDTH + TABLE_CELL_HORIZONTAL_PADDING,
+      );
+      columnWidths[columnIndex] = Math.max(
+        columnWidths[columnIndex] || 0,
+        readableWidth,
+      );
+    });
+  });
+
+  return columnWidths.reduce((total, width) => total + width, 0);
+}
+
 export default function MarkdownProse({ children, size = "article" }) {
   const bodyColor = useColorModeValue("gray.700", "gray.300");
   const headingColor = useColorModeValue("gray.800", "gray.100");
@@ -186,35 +239,40 @@ export default function MarkdownProse({ children, size = "article" }) {
     li: ({ children }) => (
       <ListItem lineHeight={lineHeight}>{children}</ListItem>
     ),
-    table: ({ children }) => (
-      <TableContainer
-        w="100%"
-        maxW="100%"
-        role="region"
-        aria-label="Markdown data table. Scroll horizontally on smaller screens."
-        tabIndex={0}
-        mb={paragraphMb}
-        overflowX="auto"
-        overflowY="hidden"
-        whiteSpace="normal"
-        borderWidth="1px"
-        borderColor={tableBorder}
-        borderRadius="md"
-        sx={{ WebkitOverflowScrolling: "touch" }}
-      >
-        <Table
-          aria-label="Markdown data table"
-          w="fit-content"
-          minW="100%"
-          size={size === "compact" ? "sm" : "md"}
-          variant="simple"
+    table: ({ children, node }) => {
+      const contentMinWidth = tableContentMinWidth(node);
+      const mobileMinWidth = Math.max(contentMinWidth, TABLE_MINIMUM_COLUMN_WIDTH);
+
+      return (
+        <TableContainer
+          w="100%"
+          maxW="100%"
+          role="region"
+          aria-label="Markdown data table. Scroll horizontally on smaller screens."
+          tabIndex={0}
+          mb={paragraphMb}
+          overflowX="auto"
+          overflowY="hidden"
           whiteSpace="normal"
-          sx={{ tableLayout: "auto" }}
+          borderWidth="1px"
+          borderColor={tableBorder}
+          borderRadius="md"
+          sx={{ WebkitOverflowScrolling: "touch" }}
         >
-          {children}
-        </Table>
-      </TableContainer>
-    ),
+          <Table
+            aria-label="Markdown data table"
+            w="fit-content"
+            minW={{ base: `max(100%, ${mobileMinWidth}px)`, md: "100%" }}
+            size={size === "compact" ? "sm" : "md"}
+            variant="simple"
+            whiteSpace="normal"
+            sx={{ tableLayout: "auto" }}
+          >
+            {children}
+          </Table>
+        </TableContainer>
+      );
+    },
     thead: ({ children }) => <Thead bg={tableHeaderBg}>{children}</Thead>,
     tbody: ({ children }) => (
       <Tbody sx={{ "tr:nth-of-type(even)": { bg: tableStripeBg } }}>
@@ -237,7 +295,8 @@ export default function MarkdownProse({ children, size = "article" }) {
         textTransform="none"
         letterSpacing="normal"
         textAlign={style?.textAlign}
-        whiteSpace="nowrap"
+        whiteSpace="normal"
+        wordBreak="break-word"
       >
         {children}
       </Th>

--- a/components/markdown-prose.js
+++ b/components/markdown-prose.js
@@ -209,14 +209,7 @@ export default function MarkdownProse({ children, size = "article" }) {
           size={size === "compact" ? "sm" : "md"}
           variant="simple"
           whiteSpace="normal"
-          sx={{
-            tableLayout: "auto",
-            "@media screen and (max-width: 47.99em)": {
-              "&:has(th:nth-child(3))": {
-                minWidth: "36rem",
-              },
-            },
-          }}
+          sx={{ tableLayout: "auto" }}
         >
           {children}
         </Table>
@@ -244,8 +237,7 @@ export default function MarkdownProse({ children, size = "article" }) {
         textTransform="none"
         letterSpacing="normal"
         textAlign={style?.textAlign}
-        whiteSpace="normal"
-        wordBreak="break-word"
+        whiteSpace="nowrap"
       >
         {children}
       </Th>

--- a/components/markdown-prose.js
+++ b/components/markdown-prose.js
@@ -205,11 +205,18 @@ export default function MarkdownProse({ children, size = "article" }) {
         <Table
           aria-label="Markdown data table"
           w="fit-content"
-          minW={{ base: "36rem", md: "100%" }}
+          minW="100%"
           size={size === "compact" ? "sm" : "md"}
           variant="simple"
           whiteSpace="normal"
-          sx={{ tableLayout: "auto" }}
+          sx={{
+            tableLayout: "auto",
+            "@media screen and (max-width: 47.99em)": {
+              "&:has(th:nth-child(3))": {
+                minWidth: "36rem",
+              },
+            },
+          }}
         >
           {children}
         </Table>

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -27,23 +27,23 @@ const NavBar = (props) => {
   const { path } = props;
   const navBg = useColorModeValue(
     "rgba(247, 245, 242, 0.75)",
-    "rgba(18, 18, 22, 0.65)"
+    "rgba(18, 18, 22, 0.65)",
   );
   const borderColor = useColorModeValue("gray.200", "gray.700");
   const menuBg = useColorModeValue("white", "gray.800");
   const menuItemActiveColor = useColorModeValue("gray.900", "white");
   const menuItemInactiveColor = useColorModeValue("gray.600", "gray.300");
   const menuItemHoverBg = useColorModeValue("gray.50", "whiteAlpha.100");
-  
+
   return (
     <Box
       position="fixed"
       as="nav"
       w="100%"
       bg={navBg}
-      style={{ 
-        backdropFilter: "blur(16px) saturate(180%)", 
-        WebkitBackdropFilter: "blur(16px) saturate(180%)" 
+      style={{
+        backdropFilter: "blur(16px) saturate(180%)",
+        WebkitBackdropFilter: "blur(16px) saturate(180%)",
       }}
       zIndex={10}
       top={0}
@@ -52,22 +52,13 @@ const NavBar = (props) => {
       borderBottomColor={borderColor}
       boxShadow={useColorModeValue(
         "0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06)",
-        "0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2)"
+        "0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2)",
       )}
       transition="all 0.2s ease-in-out"
       {...props}
     >
-      <Container
-        maxW="container.md"
-        px={{ base: 4, md: 6 }}
-        py={3}
-      >
-        <Flex
-          align="center"
-          justify="space-between"
-          wrap="wrap"
-          gap={2}
-        >
+      <Container maxW="container.md" px={{ base: 4, md: 6 }} py={3}>
+        <Flex align="center" justify="space-between" wrap="wrap" gap={2}>
           <Flex align="center" flexShrink={0}>
             <Heading as="p" size="lg" letterSpacing={"tighter"}>
               <Logo />
@@ -108,80 +99,98 @@ const NavBar = (props) => {
           <Flex align="center" gap={2} flexShrink={0}>
             <ThemeToggleButton />
             <Box display={{ base: "inline-block", md: "none" }}>
-            <Menu isLazy id="navbar-menu">
-              <MenuButton
-                as={IconButton}
-                icon={<HamburgerIcon />}
-                variant="ghost"
-                aria-label="Options"
-                colorScheme="orange"
-                _hover={{
-                  bg: useColorModeValue("orange.50", "orange.800"),
-                }}
-                _active={{
-                  bg: useColorModeValue("orange.100", "orange.700"),
-                }}
-              />
-              <MenuList
-                bg={menuBg}
-                borderColor={borderColor}
-                boxShadow="lg"
-              >
-                <MenuItem
-                  as={MenuLink}
-                  href="/articles"
-                  bg="transparent"
-                  color={path === "/articles" ? menuItemActiveColor : menuItemInactiveColor}
-                  fontWeight={path === "/articles" ? "semibold" : "normal"}
-                  _hover={{ bg: menuItemHoverBg, color: menuItemActiveColor }}
-                >
-                  Articles
-                </MenuItem>
-                <MenuItem
-                  as={MenuLink}
-                  href="/books"
-                  bg="transparent"
-                  color={path === "/books" ? menuItemActiveColor : menuItemInactiveColor}
-                  fontWeight={path === "/books" ? "semibold" : "normal"}
-                  _hover={{ bg: menuItemHoverBg, color: menuItemActiveColor }}
-                >
-                  Books
-                </MenuItem>
-                <MenuItem
-                  as={MenuLink}
-                  href="/projects"
-                  bg="transparent"
-                  color={path === "/projects" ? menuItemActiveColor : menuItemInactiveColor}
-                  fontWeight={path === "/projects" ? "semibold" : "normal"}
-                  _hover={{ bg: menuItemHoverBg, color: menuItemActiveColor }}
-                >
-                  Projects
-                </MenuItem>
-                <MenuItem
-                  as={MenuLink}
-                  href="/contacts"
-                  bg="transparent"
-                  color={path === "/contacts" ? menuItemActiveColor : menuItemInactiveColor}
-                  fontWeight={path === "/contacts" ? "semibold" : "normal"}
+              <Menu isLazy id="navbar-menu">
+                <MenuButton
+                  as={IconButton}
+                  icon={<HamburgerIcon />}
+                  variant="ghost"
+                  aria-label="Options"
+                  colorScheme="orange"
+                  size="lg"
                   _hover={{
-                    bg: menuItemHoverBg,
-                    color: menuItemActiveColor,
+                    bg: useColorModeValue("orange.50", "orange.800"),
                   }}
-                >
-                  Contacts
-                </MenuItem>
-                <MenuItem
-                  as={MenuLink}
-                  href="https://github.com/ozzgio/ozzoblog/"
-                  bg="transparent"
-                  color={menuItemInactiveColor}
-                  _hover={{ bg: menuItemHoverBg, color: menuItemActiveColor }}
-                >
-                  Source Code
-                </MenuItem>
-              </MenuList>
-            </Menu>
-          </Box>
+                  _active={{
+                    bg: useColorModeValue("orange.100", "orange.700"),
+                  }}
+                />
+                <MenuList bg={menuBg} borderColor={borderColor} boxShadow="lg">
+                  <MenuItem
+                    as={MenuLink}
+                    href="/articles"
+                    bg="transparent"
+                    color={
+                      path === "/articles"
+                        ? menuItemActiveColor
+                        : menuItemInactiveColor
+                    }
+                    fontWeight={path === "/articles" ? "semibold" : "normal"}
+                    minH="44px"
+                    _hover={{ bg: menuItemHoverBg, color: menuItemActiveColor }}
+                  >
+                    Articles
+                  </MenuItem>
+                  <MenuItem
+                    as={MenuLink}
+                    href="/books"
+                    bg="transparent"
+                    color={
+                      path === "/books"
+                        ? menuItemActiveColor
+                        : menuItemInactiveColor
+                    }
+                    fontWeight={path === "/books" ? "semibold" : "normal"}
+                    minH="44px"
+                    _hover={{ bg: menuItemHoverBg, color: menuItemActiveColor }}
+                  >
+                    Books
+                  </MenuItem>
+                  <MenuItem
+                    as={MenuLink}
+                    href="/projects"
+                    bg="transparent"
+                    color={
+                      path === "/projects"
+                        ? menuItemActiveColor
+                        : menuItemInactiveColor
+                    }
+                    fontWeight={path === "/projects" ? "semibold" : "normal"}
+                    minH="44px"
+                    _hover={{ bg: menuItemHoverBg, color: menuItemActiveColor }}
+                  >
+                    Projects
+                  </MenuItem>
+                  <MenuItem
+                    as={MenuLink}
+                    href="/contacts"
+                    bg="transparent"
+                    color={
+                      path === "/contacts"
+                        ? menuItemActiveColor
+                        : menuItemInactiveColor
+                    }
+                    fontWeight={path === "/contacts" ? "semibold" : "normal"}
+                    minH="44px"
+                    _hover={{
+                      bg: menuItemHoverBg,
+                      color: menuItemActiveColor,
+                    }}
+                  >
+                    Contacts
+                  </MenuItem>
+                  <MenuItem
+                    as={MenuLink}
+                    href="https://github.com/ozzgio/ozzoblog/"
+                    bg="transparent"
+                    color={menuItemInactiveColor}
+                    minH="44px"
+                    _hover={{ bg: menuItemHoverBg, color: menuItemActiveColor }}
+                  >
+                    Source Code
+                  </MenuItem>
+                </MenuList>
+              </Menu>
+            </Box>
           </Flex>
         </Flex>
       </Container>

--- a/components/themebutton.js
+++ b/components/themebutton.js
@@ -10,6 +10,7 @@ const ThemeToggleButton = () => {
       colorScheme={colorMode === "light" ? "purple" : "orange"}
       icon={colorMode === "light" ? <MoonIcon /> : <SunIcon />}
       onClick={toggleColorMode}
+      size="lg"
     />
   );
 };

--- a/pages/404.js
+++ b/pages/404.js
@@ -25,7 +25,7 @@ const ErrorPage = () => {
         <Text>The page you&apos;re looking for was not found.</Text>
         <Divider my={6} />
         <Box my={6} align="center">
-          <Button as={NextLink} href="/" colorScheme="orange">
+          <Button as={NextLink} href="/" colorScheme="orange" minH="44px">
             Return to home
           </Button>
         </Box>

--- a/pages/articles/index.js
+++ b/pages/articles/index.js
@@ -101,7 +101,9 @@ const ArticlesPage = ({ articles, error }) => {
       .filter((article) => article.date)
       .map((article) => {
         const formattedDate =
-          isMounted && article.date ? formatDate(article.date) : article.date || "";
+          isMounted && article.date
+            ? formatDate(article.date)
+            : article.date || "";
         const content = getArticleBody(article);
 
         return {
@@ -110,7 +112,9 @@ const ArticlesPage = ({ articles, error }) => {
           summary: article.summary || getArticleSummary(article),
           formattedDate: formattedDate || article.date || "",
           absoluteDate: article.date ? formatAbsoluteDate(article.date) : "",
-          year: article.date ? String(new Date(article.date).getFullYear()) : "",
+          year: article.date
+            ? String(new Date(article.date).getFullYear())
+            : "",
           book: String(article.book || ""),
           book_url: String(article.book_url || ""),
         };
@@ -152,9 +156,17 @@ const ArticlesPage = ({ articles, error }) => {
     const query = searchQuery.trim().toLowerCase();
 
     return sortedArticles.filter((article) => {
-      const matchesTag = selectedTag ? article.tags?.includes(selectedTag) : true;
+      const matchesTag = selectedTag
+        ? article.tags?.includes(selectedTag)
+        : true;
       const matchesQuery = query
-        ? [article.title, article.description, article.content, article.book, ...(article.tags || [])]
+        ? [
+            article.title,
+            article.description,
+            article.content,
+            article.book,
+            ...(article.tags || []),
+          ]
             .join(" ")
             .toLowerCase()
             .includes(query)
@@ -167,7 +179,9 @@ const ArticlesPage = ({ articles, error }) => {
   const latestArticle = sortedArticles[0] || null;
 
   const uniqueYears = useMemo(
-    () => [...new Set(sortedArticles.map((article) => article.year).filter(Boolean))],
+    () => [
+      ...new Set(sortedArticles.map((article) => article.year).filter(Boolean)),
+    ],
     [sortedArticles],
   );
 
@@ -341,19 +355,21 @@ const ArticlesPage = ({ articles, error }) => {
               >
                 <Stack direction={{ base: "column", xl: "row" }} spacing={4}>
                   <InputGroup flex={1}>
-                    <InputLeftElement pointerEvents="none">
+                    <InputLeftElement pointerEvents="none" h="44px">
                       <Icon as={IoSearchOutline} color="gray.400" />
                     </InputLeftElement>
                     <Input
                       placeholder="Search titles, summaries, notes, or tags"
                       value={searchQuery}
                       onChange={(event) => setSearchQuery(event.target.value)}
+                      minH="44px"
                     />
                   </InputGroup>
                   <Select
                     value={sortOption}
                     onChange={(event) => setSortOption(event.target.value)}
                     maxW={{ base: "100%", xl: "220px" }}
+                    minH="44px"
                   >
                     <option value="newest">Newest First</option>
                     <option value="oldest">Oldest First</option>
@@ -365,6 +381,7 @@ const ArticlesPage = ({ articles, error }) => {
                       variant="ghost"
                       colorScheme="orange"
                       onClick={resetFilters}
+                      minH="44px"
                     >
                       Clear filters
                     </Button>
@@ -375,6 +392,7 @@ const ArticlesPage = ({ articles, error }) => {
                   <WrapItem>
                     <Button
                       size="sm"
+                      minH="44px"
                       colorScheme={!selectedTag ? "orange" : "gray"}
                       variant={!selectedTag ? "solid" : "outline"}
                       onClick={() => setSelectedTag(null)}
@@ -386,6 +404,7 @@ const ArticlesPage = ({ articles, error }) => {
                     <WrapItem key={tag}>
                       <Button
                         size="sm"
+                        minH="44px"
                         colorScheme="orange"
                         variant={selectedTag === tag ? "solid" : "outline"}
                         onClick={() => setSelectedTag(tag)}
@@ -396,7 +415,13 @@ const ArticlesPage = ({ articles, error }) => {
                   ))}
                 </Wrap>
 
-                <HStack mt={4} spacing={3} color={mutedText} fontSize="sm" flexWrap="wrap">
+                <HStack
+                  mt={4}
+                  spacing={3}
+                  color={mutedText}
+                  fontSize="sm"
+                  flexWrap="wrap"
+                >
                   <HStack spacing={1}>
                     <Icon as={IoTimeOutline} />
                     <Text>{filteredArticles.length} selected</Text>
@@ -422,7 +447,12 @@ const ArticlesPage = ({ articles, error }) => {
                   textAlign="center"
                   bg={accentSubtle}
                 >
-                  <Icon as={IoFlashOutline} boxSize={8} color="orange.400" mb={3} />
+                  <Icon
+                    as={IoFlashOutline}
+                    boxSize={8}
+                    color="orange.400"
+                    mb={3}
+                  />
                   <Heading as="h2" size="md" mb={2}>
                     No articles found
                   </Heading>
@@ -433,7 +463,10 @@ const ArticlesPage = ({ articles, error }) => {
               ) : (
                 <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
                   {filteredArticles.map((article) => (
-                    <ArticleCard key={article.slug || article.url} {...article} />
+                    <ArticleCard
+                      key={article.slug || article.url}
+                      {...article}
+                    />
                   ))}
                 </SimpleGrid>
               )}

--- a/pages/books/[slug].js
+++ b/pages/books/[slug].js
@@ -6,9 +6,12 @@ import {
   Icon,
   Image,
   Link,
+  Stack,
   Tag,
   Text,
   VStack,
+  Wrap,
+  WrapItem,
   useColorModeValue,
   Divider,
 } from "@chakra-ui/react";
@@ -60,6 +63,15 @@ function iconForLabel(label) {
   return match ? match[1] : IoChatbubbleOutline;
 }
 
+function sectionId(label, index) {
+  const slug = String(label)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  return `reading-arc-${index}-${slug || "note"}`;
+}
+
 function ReadingArc({ sections }) {
   const railColor = useColorModeValue("orange.300", "orange.600");
   const markerBg = useColorModeValue("white", "#1a1a1e");
@@ -69,6 +81,7 @@ function ReadingArc({ sections }) {
 
   return (
     <Box
+      as="ol"
       borderLeftWidth="2px"
       borderLeftColor={railColor}
       ml={{ base: 2, md: 3 }}
@@ -80,8 +93,16 @@ function ReadingArc({ sections }) {
         const isDecision = /decision|decided/i.test(section.label);
         const isLast = index === sections.length - 1;
 
+        const headingId = sectionId(section.label, index);
+
         return (
-          <Box key={section.label} position="relative" pb={isLast ? 0 : 7}>
+          <Box
+            as="li"
+            key={`${section.label}-${index}`}
+            position="relative"
+            pb={isLast ? 0 : 8}
+            listStyleType="none"
+          >
             <Box
               position="absolute"
               left={{ base: "-37px", md: "-49px" }}
@@ -95,10 +116,16 @@ function ReadingArc({ sections }) {
               alignItems="center"
               justifyContent="center"
             >
-              <Icon as={iconForLabel(section.label)} boxSize={{ base: 3, md: 3.5 }} color={railColor} />
+              <Icon
+                as={iconForLabel(section.label)}
+                boxSize={{ base: 3, md: 3.5 }}
+                color={railColor}
+              />
             </Box>
 
-            <Text
+            <Heading
+              as="h3"
+              id={headingId}
               fontSize="xs"
               fontWeight="bold"
               textTransform="uppercase"
@@ -107,7 +134,7 @@ function ReadingArc({ sections }) {
               mb={2}
             >
               {section.label}
-            </Text>
+            </Heading>
 
             {isDecision ? (
               <Box
@@ -157,14 +184,18 @@ export default function BookDetailPage({ book }) {
     book.problem && { label: "Why I picked this up", body: book.problem },
     book.concept && { label: "What it teaches", body: book.concept },
     book.decision && { label: "What I decided", body: book.decision },
-    book.implementation && { label: "Implementation", body: book.implementation },
+    book.implementation && {
+      label: "Implementation",
+      body: book.implementation,
+    },
     book.effect && { label: "What changed", body: book.effect },
     book.trade_off && { label: "Critical reflection", body: book.trade_off },
   ].filter(Boolean);
 
-  const sections = structuredSections.length > 0
-    ? structuredSections
-    : parseBookNotesSections(book.notes);
+  const sections =
+    structuredSections.length > 0
+      ? structuredSections
+      : parseBookNotesSections(book.notes);
 
   const hasArc = sections.length > 0;
   const hasQuotes = book.quotes?.length > 0;
@@ -179,13 +210,24 @@ export default function BookDetailPage({ book }) {
         <link rel="canonical" href={canonicalUrl} />
       </Head>
 
-      <Container maxW="2xl" py={{ base: 6, md: 10 }}>
-        <VStack align="start" spacing={8}>
+      <Container maxW="3xl" py={{ base: 6, md: 12 }}>
+        <VStack
+          align="start"
+          spacing={{ base: 9, md: 12 }}
+          w="100%"
+          maxW="2xl"
+          mx="auto"
+        >
           <Link
             as={NextLink}
             href="/books"
             color={linkOrange}
             fontWeight="semibold"
+            minH="44px"
+            display="inline-flex"
+            alignItems="center"
+            px={2}
+            mx={-2}
           >
             <HStack spacing={1}>
               <Icon as={IoArrowBackOutline} />
@@ -193,59 +235,118 @@ export default function BookDetailPage({ book }) {
             </HStack>
           </Link>
 
-          <HStack align="start" spacing={{ base: 4, md: 6 }} w="100%" flexWrap="wrap">
-            {book.cover && (
-              <Image
-                src={book.cover}
-                alt={book.title}
-                flexShrink={0}
-                w={{ base: "92px", md: "120px" }}
-                borderRadius="md"
-                boxShadow="lg"
-                objectFit="cover"
-              />
-            )}
-            <VStack align="start" spacing={3} flex={1} minW="200px">
-              <Heading
-                as="h1"
-                size="lg"
-                lineHeight="1.2"
-                color={headingColor}
-                fontFamily={READING_FONT}
-              >
-                {book.title}
-              </Heading>
-              <HStack spacing={2} color={mutedText} fontSize="sm">
-                <Icon as={IoBookOutline} />
-                <Text fontWeight="medium">{book.author}</Text>
-                {book.date && (
-                  <>
-                    <Text aria-hidden="true">&middot;</Text>
-                    <Icon as={IoCalendarOutline} />
-                    <Text>Read {formatAbsoluteDate(book.date)}</Text>
-                  </>
-                )}
-              </HStack>
-              {book.rating > 0 && (
-                <HStack spacing={2}>
-                  <RatingStar rating={book.rating} />
-                  <Text color={linkOrange} fontWeight="bold" fontSize="sm">
-                    {book.rating}/5
-                  </Text>
-                </HStack>
+          <Box
+            w="100%"
+            borderWidth="1px"
+            borderColor={proseBorder}
+            borderRadius={{ base: "2xl", md: "3xl" }}
+            bg={quoteBg}
+            p={{ base: 5, md: 8 }}
+          >
+            <Stack
+              direction={{ base: "column", sm: "row" }}
+              align={{ base: "start", sm: "center" }}
+              spacing={{ base: 5, md: 8 }}
+            >
+              {book.cover && (
+                <Box
+                  w={{ base: "132px", md: "160px" }}
+                  flexShrink={0}
+                  alignSelf={{ base: "center", sm: "start" }}
+                >
+                  <Image
+                    src={book.cover}
+                    alt={`Cover of ${book.title}`}
+                    w="100%"
+                    borderRadius="lg"
+                    boxShadow="xl"
+                    objectFit="cover"
+                  />
+                </Box>
               )}
-              <HStack flexWrap="wrap" spacing={2}>
-                {book.tags?.map((tag) => (
-                  <Tag key={tag} colorScheme="orange" borderRadius="full" size="sm">
-                    {tag}
-                  </Tag>
-                ))}
-              </HStack>
-            </VStack>
-          </HStack>
+              <VStack align="start" spacing={4} flex={1} minW={0}>
+                <Text
+                  fontSize="xs"
+                  fontWeight="bold"
+                  textTransform="uppercase"
+                  letterSpacing="widest"
+                  color={linkOrange}
+                >
+                  Reading notes
+                </Text>
+                <Heading
+                  as="h1"
+                  fontSize={{ base: "3xl", md: "4xl" }}
+                  lineHeight="1.05"
+                  color={headingColor}
+                  fontFamily={READING_FONT}
+                >
+                  {book.title}
+                </Heading>
+                <Wrap spacingX={4} spacingY={2} color={mutedText} fontSize="sm">
+                  <WrapItem>
+                    <HStack spacing={2}>
+                      <Icon as={IoBookOutline} />
+                      <Text fontWeight="medium">{book.author}</Text>
+                    </HStack>
+                  </WrapItem>
+                  {book.date && (
+                    <WrapItem>
+                      <HStack spacing={2}>
+                        <Icon as={IoCalendarOutline} />
+                        <Text>Read {formatAbsoluteDate(book.date)}</Text>
+                      </HStack>
+                    </WrapItem>
+                  )}
+                </Wrap>
+                {book.rating > 0 && (
+                  <HStack spacing={2}>
+                    <RatingStar rating={book.rating} />
+                    <Text color={linkOrange} fontWeight="bold" fontSize="sm">
+                      {book.rating}/5
+                    </Text>
+                  </HStack>
+                )}
+                <HStack flexWrap="wrap" spacing={2}>
+                  {book.tags?.map((tag) => (
+                    <Tag
+                      key={tag}
+                      colorScheme="orange"
+                      borderRadius="full"
+                      size="sm"
+                    >
+                      {tag}
+                    </Tag>
+                  ))}
+                </HStack>
+              </VStack>
+            </Stack>
+          </Box>
 
           {book.lesson && (
-            <Box w="100%" borderLeftWidth="3px" borderLeftColor="orange.400" pl={4} py={1}>
+            <Box
+              as="section"
+              aria-labelledby="book-takeaway"
+              w="100%"
+              borderLeftWidth="3px"
+              borderLeftColor="orange.400"
+              bg={quoteBg}
+              borderRadius="0 xl xl 0"
+              pl={{ base: 5, md: 6 }}
+              pr={{ base: 4, md: 6 }}
+              py={{ base: 4, md: 5 }}
+            >
+              <Heading
+                as="h2"
+                id="book-takeaway"
+                fontSize="xs"
+                textTransform="uppercase"
+                letterSpacing="widest"
+                color={linkOrange}
+                mb={3}
+              >
+                The idea I kept
+              </Heading>
               <Text
                 fontStyle="italic"
                 color={bodyColor}
@@ -260,8 +361,14 @@ export default function BookDetailPage({ book }) {
 
           {hasArc && (
             <VStack align="start" spacing={4} w="100%">
-              <Heading as="h2" size="sm" color={mutedText} textTransform="uppercase" letterSpacing="wider">
-                My read
+              <Heading
+                as="h2"
+                size="sm"
+                color={mutedText}
+                textTransform="uppercase"
+                letterSpacing="wider"
+              >
+                Reading arc
               </Heading>
               <ReadingArc sections={sections} />
             </VStack>
@@ -273,7 +380,13 @@ export default function BookDetailPage({ book }) {
               <VStack align="start" spacing={4} w="100%">
                 <HStack spacing={2}>
                   <Icon as={IoChatbubbleOutline} color="orange.400" />
-                  <Heading as="h2" size="sm" color={mutedText} textTransform="uppercase" letterSpacing="wider">
+                  <Heading
+                    as="h2"
+                    size="sm"
+                    color={mutedText}
+                    textTransform="uppercase"
+                    letterSpacing="wider"
+                  >
                     Notable quotes
                   </Heading>
                 </HStack>
@@ -289,7 +402,12 @@ export default function BookDetailPage({ book }) {
                       bg={quoteBg}
                       borderRadius="sm"
                     >
-                      <Text fontSize="sm" fontStyle="italic" color={bodyColor} lineHeight="1.7">
+                      <Text
+                        fontSize="sm"
+                        fontStyle="italic"
+                        color={bodyColor}
+                        lineHeight="1.7"
+                      >
                         {quote}
                       </Text>
                     </Box>
@@ -318,8 +436,10 @@ export default function BookDetailPage({ book }) {
                   fontWeight="semibold"
                   isExternal
                   fontSize="sm"
+                  minH="44px"
                   mt={2}
-                  display="block"
+                  display="inline-flex"
+                  alignItems="center"
                 >
                   Open original link
                 </Link>

--- a/pages/books/index.js
+++ b/pages/books/index.js
@@ -60,7 +60,8 @@ const sortByDate = (a, b, direction = "desc") => {
   const dateA = a.date ? new Date(a.date).getTime() : null;
   const dateB = b.date ? new Date(b.date).getTime() : null;
 
-  if (dateA && dateB) return direction === "desc" ? dateB - dateA : dateA - dateB;
+  if (dateA && dateB)
+    return direction === "desc" ? dateB - dateA : dateA - dateB;
   if (dateA) return direction === "desc" ? -1 : 1;
   if (dateB) return direction === "desc" ? 1 : -1;
   return 0;
@@ -128,26 +129,30 @@ const BooksPage = ({ books, error }) => {
 
     if (sortOption === "highest_rating") {
       currentBooks.sort((a, b) => {
-        if ((b.rating ?? 0) !== (a.rating ?? 0)) return (b.rating ?? 0) - (a.rating ?? 0);
+        if ((b.rating ?? 0) !== (a.rating ?? 0))
+          return (b.rating ?? 0) - (a.rating ?? 0);
         return sortByDate(a, b, "desc") || a.title.localeCompare(b.title);
       });
     } else if (sortOption === "lowest_rating") {
       currentBooks.sort((a, b) => {
-        if ((a.rating ?? 0) !== (b.rating ?? 0)) return (a.rating ?? 0) - (b.rating ?? 0);
+        if ((a.rating ?? 0) !== (b.rating ?? 0))
+          return (a.rating ?? 0) - (b.rating ?? 0);
         return sortByDate(a, b, "desc") || a.title.localeCompare(b.title);
       });
     } else if (sortOption === "newest") {
       currentBooks.sort((a, b) => {
         const byDate = sortByDate(a, b, "desc");
         if (byDate !== 0) return byDate;
-        if ((b.rating ?? 0) !== (a.rating ?? 0)) return (b.rating ?? 0) - (a.rating ?? 0);
+        if ((b.rating ?? 0) !== (a.rating ?? 0))
+          return (b.rating ?? 0) - (a.rating ?? 0);
         return a.title.localeCompare(b.title);
       });
     } else if (sortOption === "oldest") {
       currentBooks.sort((a, b) => {
         const byDate = sortByDate(a, b, "asc");
         if (byDate !== 0) return byDate;
-        if ((b.rating ?? 0) !== (a.rating ?? 0)) return (b.rating ?? 0) - (a.rating ?? 0);
+        if ((b.rating ?? 0) !== (a.rating ?? 0))
+          return (b.rating ?? 0) - (a.rating ?? 0);
         return a.title.localeCompare(b.title);
       });
     } else if (sortOption === "alphabetical") {
@@ -166,7 +171,13 @@ const BooksPage = ({ books, error }) => {
     return sortedBooks.filter((book) => {
       const matchesTag = selectedTag ? book.tags?.includes(selectedTag) : true;
       const matchesQuery = query
-        ? [book.title, book.author, book.lesson, book.notes, ...(book.tags || [])]
+        ? [
+            book.title,
+            book.author,
+            book.lesson,
+            book.notes,
+            ...(book.tags || []),
+          ]
             .join(" ")
             .toLowerCase()
             .includes(query)
@@ -185,7 +196,9 @@ const BooksPage = ({ books, error }) => {
     const datedBooks = normalizedBooks.filter((book) => book.date);
     if (datedBooks.length === 0) return null;
 
-    return [...datedBooks].sort((a, b) => new Date(b.date) - new Date(a.date))[0];
+    return [...datedBooks].sort(
+      (a, b) => new Date(b.date) - new Date(a.date),
+    )[0];
   }, [normalizedBooks]);
 
   const hasActiveFilters = Boolean(selectedTag || searchQuery.trim());
@@ -261,11 +274,17 @@ const BooksPage = ({ books, error }) => {
                   Reading library
                 </Badge>
                 <Box>
-                  <Heading as="h1" fontSize={{ base: "xl", md: "2xl" }} lineHeight="1.2" mb={2}>
+                  <Heading
+                    as="h1"
+                    fontSize={{ base: "xl", md: "2xl" }}
+                    lineHeight="1.2"
+                    mb={2}
+                  >
                     Books I&apos;ve read
                   </Heading>
                   <Text fontSize="sm" color={mutedText}>
-                    Notes on what stuck, what changed, and the occasional full breakdown.
+                    Notes on what stuck, what changed, and the occasional full
+                    breakdown.
                   </Text>
                 </Box>
                 {heroMetaItems.length > 0 && (
@@ -358,19 +377,21 @@ const BooksPage = ({ books, error }) => {
               >
                 <Stack direction={{ base: "column", xl: "row" }} spacing={4}>
                   <InputGroup flex={1}>
-                    <InputLeftElement pointerEvents="none">
+                    <InputLeftElement pointerEvents="none" h="44px">
                       <Icon as={IoSearchOutline} color="gray.400" />
                     </InputLeftElement>
                     <Input
                       placeholder="Search titles, authors, notes, or tags"
                       value={searchQuery}
                       onChange={(event) => setSearchQuery(event.target.value)}
+                      minH="44px"
                     />
                   </InputGroup>
                   <Select
                     value={sortOption}
                     onChange={(event) => setSortOption(event.target.value)}
                     maxW={{ base: "100%", xl: "220px" }}
+                    minH="44px"
                   >
                     <option value="highest_rating">Highest Rating</option>
                     <option value="lowest_rating">Lowest Rating</option>
@@ -384,6 +405,7 @@ const BooksPage = ({ books, error }) => {
                       variant="ghost"
                       colorScheme="orange"
                       onClick={resetFilters}
+                      minH="44px"
                     >
                       Clear filters
                     </Button>
@@ -394,6 +416,7 @@ const BooksPage = ({ books, error }) => {
                   <WrapItem>
                     <Button
                       size="sm"
+                      minH="44px"
                       colorScheme={!selectedTag ? "orange" : "gray"}
                       variant={!selectedTag ? "solid" : "outline"}
                       onClick={() => setSelectedTag(null)}
@@ -405,6 +428,7 @@ const BooksPage = ({ books, error }) => {
                     <WrapItem key={tag}>
                       <Button
                         size="sm"
+                        minH="44px"
                         colorScheme="orange"
                         variant={selectedTag === tag ? "solid" : "outline"}
                         onClick={() => setSelectedTag(tag)}
@@ -415,7 +439,13 @@ const BooksPage = ({ books, error }) => {
                   ))}
                 </Wrap>
 
-                <HStack mt={4} spacing={3} color={mutedText} fontSize="sm" flexWrap="wrap">
+                <HStack
+                  mt={4}
+                  spacing={3}
+                  color={mutedText}
+                  fontSize="sm"
+                  flexWrap="wrap"
+                >
                   <HStack spacing={1}>
                     <Icon as={IoStarOutline} />
                     <Text>{filteredBooks.length} selected</Text>
@@ -445,7 +475,12 @@ const BooksPage = ({ books, error }) => {
                   textAlign="center"
                   bg={accentSubtle}
                 >
-                  <Icon as={IoFlashOutline} boxSize={8} color="orange.400" mb={3} />
+                  <Icon
+                    as={IoFlashOutline}
+                    boxSize={8}
+                    color="orange.400"
+                    mb={3}
+                  />
                   <Heading as="h2" size="md" mb={2}>
                     No books found
                   </Heading>
@@ -458,7 +493,12 @@ const BooksPage = ({ books, error }) => {
                   {featuredBook && (
                     <Box>
                       <HStack spacing={3} mb={4} align="center" flexWrap="wrap">
-                        <Badge colorScheme="orange" px={3} py={1} borderRadius="full">
+                        <Badge
+                          colorScheme="orange"
+                          px={3}
+                          py={1}
+                          borderRadius="full"
+                        >
                           Featured result
                         </Badge>
                         <Text fontSize="sm" color={mutedText}>
@@ -471,7 +511,13 @@ const BooksPage = ({ books, error }) => {
 
                   {bookGrid.length > 0 && (
                     <Box>
-                      <Flex justify="space-between" mb={4} gap={3} wrap="wrap" align="center">
+                      <Flex
+                        justify="space-between"
+                        mb={4}
+                        gap={3}
+                        wrap="wrap"
+                        align="center"
+                      >
                         <Heading as="h2" size="md">
                           Explore more
                         </Heading>
@@ -479,7 +525,10 @@ const BooksPage = ({ books, error }) => {
                           {bookGrid.length} remaining books
                         </Text>
                       </Flex>
-                      <SimpleGrid columns={{ base: 1, md: 2, xl: 3 }} spacing={6}>
+                      <SimpleGrid
+                        columns={{ base: 1, md: 2, xl: 3 }}
+                        spacing={6}
+                      >
                         {bookGrid.map((book) => (
                           <BookCard
                             key={book.slug || `${book.title}-${book.author}`}

--- a/pages/newsletter/confirmed.js
+++ b/pages/newsletter/confirmed.js
@@ -34,14 +34,31 @@ const NewsletterConfirmed = () => (
             maxW="sm"
             mx="auto"
           >
-            Welcome. You&apos;ll get field notes on finding demand, shipping useful
-            software, earning attention, and building toward independent work.
+            Welcome. You&apos;ll get field notes on finding demand, shipping
+            useful software, earning attention, and building toward independent
+            work.
           </Text>
-          <Stack direction={{ base: "column", sm: "row" }} spacing={3} justify="center">
-            <Button as={NextLink} href="/articles" colorScheme="orange" size="md">
+          <Stack
+            direction={{ base: "column", sm: "row" }}
+            spacing={3}
+            justify="center"
+          >
+            <Button
+              as={NextLink}
+              href="/articles"
+              colorScheme="orange"
+              size="md"
+              minH="44px"
+            >
               Read the articles
             </Button>
-            <Button as={NextLink} href="/" variant="ghost" size="md">
+            <Button
+              as={NextLink}
+              href="/"
+              variant="ghost"
+              size="md"
+              minH="44px"
+            >
               Back to home
             </Button>
           </Stack>

--- a/pages/newsletter/pending.js
+++ b/pages/newsletter/pending.js
@@ -37,7 +37,13 @@ const NewsletterPending = () => (
             We sent you a confirmation link. Click it to activate your
             subscription and start receiving one field note each week.
           </Text>
-          <Button as={NextLink} href="/" colorScheme="orange" size="md">
+          <Button
+            as={NextLink}
+            href="/"
+            colorScheme="orange"
+            size="md"
+            minH="44px"
+          >
             Back to home
           </Button>
         </Box>

--- a/scripts/verify-markdown-table-presentation.mjs
+++ b/scripts/verify-markdown-table-presentation.mjs
@@ -18,6 +18,11 @@ const COMPACT_THREE_COLUMN_TABLE_MARKDOWN = [
   "| :--- | :--- | :--- |",
   "| 1 | 2 | 3 |",
 ].join("\n");
+const VERBOSE_COMPACT_TABLE_MARKDOWN = [
+  "| Minimum supported version | Recommended deployment strategy |",
+  "| :--- | :--- |",
+  "| Version 1.0 | Container image |",
+].join("\n");
 const WIDE_TABLE_MARKDOWN = [
   "| One | Two | Three | Four | Five | Six | Seven | Eight | Nine | Ten | Eleven | Twelve | Thirteen | Fourteen |",
   "| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |",
@@ -34,6 +39,7 @@ const fixtureArticles = [{
     "This verifies article prose.",
     SHORT_TABLE_MARKDOWN,
     COMPACT_THREE_COLUMN_TABLE_MARKDOWN,
+    VERBOSE_COMPACT_TABLE_MARKDOWN,
     WIDE_TABLE_MARKDOWN,
   ].join("\n\n"),
 }];
@@ -49,6 +55,7 @@ const fixtureBooks = [{
     "**Implementation**",
     SHORT_TABLE_MARKDOWN,
     COMPACT_THREE_COLUMN_TABLE_MARKDOWN,
+    VERBOSE_COMPACT_TABLE_MARKDOWN,
     WIDE_TABLE_MARKDOWN,
   ].join("\n\n"),
 }];
@@ -285,7 +292,8 @@ const contexts = [
 const tableFixtures = [
   { name: "short table", index: 0, alignments: ["left", "right"], shouldScroll: false },
   { name: "compact three-column table", index: 1, alignments: Array(3).fill("left"), shouldScroll: false },
-  { name: "wide table", index: 2, alignments: Array(14).fill("left"), shouldScroll: true },
+  { name: "verbose compact table", index: 2, alignments: Array(2).fill("left"), shouldScroll: false },
+  { name: "wide table", index: 3, alignments: Array(14).fill("left"), shouldScroll: true },
 ];
 const mobileViewports = [
   { name: "320px mobile", width: 320, height: 720 },

--- a/scripts/verify-markdown-table-presentation.mjs
+++ b/scripts/verify-markdown-table-presentation.mjs
@@ -13,6 +13,11 @@ const SHORT_TABLE_MARKDOWN = [
   "| :--- | ---: |",
   "| Short value | 1 |",
 ].join("\n");
+const COMPACT_THREE_COLUMN_TABLE_MARKDOWN = [
+  "| A | B | C |",
+  "| :--- | :--- | :--- |",
+  "| 1 | 2 | 3 |",
+].join("\n");
 const WIDE_TABLE_MARKDOWN = [
   "| One | Two | Three | Four | Five | Six | Seven | Eight | Nine | Ten | Eleven | Twelve | Thirteen | Fourteen |",
   "| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |",
@@ -28,6 +33,7 @@ const fixtureArticles = [{
     "# Markdown table fixture",
     "This verifies article prose.",
     SHORT_TABLE_MARKDOWN,
+    COMPACT_THREE_COLUMN_TABLE_MARKDOWN,
     WIDE_TABLE_MARKDOWN,
   ].join("\n\n"),
 }];
@@ -42,6 +48,7 @@ const fixtureBooks = [{
     "This verifies the compact prose path.",
     "**Implementation**",
     SHORT_TABLE_MARKDOWN,
+    COMPACT_THREE_COLUMN_TABLE_MARKDOWN,
     WIDE_TABLE_MARKDOWN,
   ].join("\n\n"),
 }];
@@ -224,9 +231,9 @@ function assertTablePresentation(metrics, context, tableFixture, mode) {
   assert.match(metrics.containerLabel || "", /scroll horizontally/i, label + ": scroll region needs instructions");
 }
 
-async function assertMobileLayout(page, context, tableFixture, mode) {
+async function assertMobileLayout(page, context, tableFixture, mode, viewportName) {
   const metrics = await tableMetrics(page, tableFixture);
-  assertTablePresentation(metrics, context, tableFixture, mode + " mobile");
+  assertTablePresentation(metrics, context, tableFixture, mode + " " + viewportName);
 
   const viewportMetrics = await page.evaluate(() => ({
     documentWidth: document.documentElement.scrollWidth,
@@ -235,23 +242,23 @@ async function assertMobileLayout(page, context, tableFixture, mode) {
 
   assert.ok(
     viewportMetrics.documentWidth <= viewportMetrics.viewportWidth,
-    context.name + " " + tableFixture.name + " " + mode + " mobile: the page must not overflow horizontally (" +
+    context.name + " " + tableFixture.name + " " + mode + " " + viewportName + ": the page must not overflow horizontally (" +
       viewportMetrics.documentWidth + "px > " + viewportMetrics.viewportWidth + "px; table " +
       metrics.containerClientWidth + "px / " + metrics.containerScrollWidth + "px)",
   );
   assert.ok(
     ["auto", "scroll"].includes(metrics.containerOverflowX),
-    context.name + " " + tableFixture.name + " " + mode + " mobile: the container must handle horizontal overflow",
+    context.name + " " + tableFixture.name + " " + mode + " " + viewportName + ": the container must handle horizontal overflow",
   );
   if (tableFixture.shouldScroll) {
     assert.ok(
       metrics.containerScrollWidth > metrics.containerClientWidth,
-      context.name + " " + tableFixture.name + " " + mode + " mobile: wide tables must scroll inside the container",
+      context.name + " " + tableFixture.name + " " + mode + " " + viewportName + ": wide tables must scroll inside the container",
     );
   } else {
     assert.ok(
       metrics.containerScrollWidth <= metrics.containerClientWidth + 1,
-      context.name + " " + tableFixture.name + " " + mode + " mobile: fitting tables must not force horizontal panning",
+      context.name + " " + tableFixture.name + " " + mode + " " + viewportName + ": fitting tables must not force horizontal panning",
     );
   }
 }
@@ -277,7 +284,12 @@ const contexts = [
 ];
 const tableFixtures = [
   { name: "short table", index: 0, alignments: ["left", "right"], shouldScroll: false },
-  { name: "wide table", index: 1, alignments: Array(14).fill("left"), shouldScroll: true },
+  { name: "compact three-column table", index: 1, alignments: Array(3).fill("left"), shouldScroll: false },
+  { name: "wide table", index: 2, alignments: Array(14).fill("left"), shouldScroll: true },
+];
+const mobileViewports = [
+  { name: "320px mobile", width: 320, height: 720 },
+  { name: "390px mobile", width: 390, height: 844 },
 ];
 
 const fixture = await createFixtureServer();
@@ -311,16 +323,18 @@ try {
       );
     }
 
-    await page.setViewportSize({ width: 390, height: 844 });
-    await page.reload({ waitUntil: "networkidle" });
-    await setColorMode(page, "dark");
-    for (const tableFixture of tableFixtures) {
-      await assertMobileLayout(page, proseContext, tableFixture, "dark");
-    }
+    for (const viewport of mobileViewports) {
+      await page.setViewportSize(viewport);
+      await page.reload({ waitUntil: "networkidle" });
+      await setColorMode(page, "dark");
+      for (const tableFixture of tableFixtures) {
+        await assertMobileLayout(page, proseContext, tableFixture, "dark", viewport.name);
+      }
 
-    await setColorMode(page, "light");
-    for (const tableFixture of tableFixtures) {
-      await assertMobileLayout(page, proseContext, tableFixture, "light");
+      await setColorMode(page, "light");
+      for (const tableFixture of tableFixtures) {
+        await assertMobileLayout(page, proseContext, tableFixture, "light", viewport.name);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- make shared navigation, filter, newsletter, and status-page controls meet the 44px touch target
- redesign book-detail mastheads for long titles, with a readable takeaway and semantic reading arc
- retain the existing editorial visual language across light and dark modes

## Validation
- npm run lint
- npm run build
- npm run verify:markdown
- npm run verify:markdown:presentation
- full browser matrix: 44 public routes x 3 viewports x 2 themes = 264 checks; no overflow, missing H1, or undersized audited control
- interaction checks: article/book search + empty states, clear filters, theme toggle, mobile menu, newsletter native validation

## NUC preview
- temporary preview: http://192.168.1.44:3011
- https://ozzoblog-dev.nuc/ currently returns a pre-existing OpenResty 502 and is not routing to an Ozzoblog service; no shared-proxy repair was made in this PR.

## Manual visual QA
- see the checklist in the final handoff before merge