### PR TITLE
ci: automate dependency and quality checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Rome
+    open-pull-requests-limit: 5
+    groups:
+      development-patch-minor:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      production-patch-minor:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Rome
+    open-pull-requests-limit: 3
+    groups:
+      workflow-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,32 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "31 4 * * 4"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+      - name: Analyze code
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -1,0 +1,41 @@
+name: Dependency Health
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 4 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: moderate
+
+  npm-audit:
+    name: npm audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Audit dependencies
+        run: npm audit --audit-level=high

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ The SEO health workflow (`.github/workflows/seo-health.yml`) runs on every PR an
 - Verifies every URL in `public/sitemap.xml` returns 200
 - Checks key pages carry all required SEO tags: `title`, `meta description`, `canonical`, `og:*`, `twitter:card`
 
+## Security and quality automation
+
+- Dependabot opens grouped weekly npm and GitHub Actions update PRs. Security updates are grouped separately from normal version updates.
+- Dependency Health runs Dependency Review plus a full dependency audit on every PR and `main` push, and repeats weekly.
+- CodeQL runs the JavaScript/TypeScript `security-and-quality` suite on PRs, `main`, and weekly.
+
 ---
 
 ## Content pipeline


### PR DESCRIPTION
## Summary
- add grouped weekly Dependabot updates for npm and GitHub Actions
- add Dependency Review and npm audit gates for pull requests, `main`, and weekly runs
- add CodeQL JavaScript/TypeScript security-and-quality scanning

## Validation
- `npm run lint`
- `npm run verify:markdown`
- `npm run verify:markdown:presentation`
- `npm run build`
- YAML parse checks

## Known current result
`npm audit --audit-level=high` correctly fails today on the existing dependency debt: 8 npm advisories (6 high, 2 moderate), corresponding to the repository’s 23 Dependabot alerts. The follow-up security-update PR should make this required check green.